### PR TITLE
Store and use default subcategory/subdirectory in manifest file

### DIFF
--- a/classes/cli_helper.php
+++ b/classes/cli_helper.php
@@ -685,7 +685,7 @@ class cli_helper {
                 echo "Question category: {$moodlequestionlist->contextinfo->qcategoryname}\n";
             }
             if ($defaultwarning && !isset($activity->subdirectory)) {
-                echo "Using default question category from manifest file.\n";
+                echo "\nUsing default question category from manifest file.\n";
                 echo "Set --subcategory or --questioncategoryid to override.\n";
             }
             static::handle_abort();

--- a/classes/cli_helper.php
+++ b/classes/cli_helper.php
@@ -678,7 +678,7 @@ class cli_helper {
             if (isset($activity->subdirectory)) {
                 echo "Question subdirectory: {$activity->subdirectory}\n";
                 if ($defaultwarning) {
-                    echo "Using default subdirectory from manifest file.\n";
+                    echo "\nUsing default subdirectory from manifest file.\n";
                     echo "Set --subdirectory to override.\n";
                 }
             } else {

--- a/classes/cli_helper.php
+++ b/classes/cli_helper.php
@@ -642,8 +642,8 @@ class cli_helper {
      * is valid and then confirm with user it's the right one.
      *
      * @param object $activity
-     * @param boolean $defaultwarning If true, display using subcat default warning
-     * @param boolean $silent If true, don't display returned info
+     * @param bool $defaultwarning If true, display using subcat default warning
+     * @param bool $silent If true, don't display returned info
      * @return object
      */
     public function check_context(object $activity, bool $defaultwarning=false, bool $silent=false):object {

--- a/classes/cli_helper.php
+++ b/classes/cli_helper.php
@@ -165,7 +165,7 @@ class cli_helper {
                 }
             }
             if (strlen($cliargs['subdirectory']) === 0) {
-                $cliargs['subdirectory'] = 'top';
+                $cliargs['subdirectory'] = null;
             }
         }
         if (isset($cliargs['subcategory'])) {
@@ -395,11 +395,15 @@ class cli_helper {
      * @param string $tempfilepath
      * @param string $manifestpath
      * @param string $moodleurl
+     * @param int|null $subcategoryid
+     * @param string|null $subdirectory
      * @param bool $showupdated
      * @return object
      */
     public static function create_manifest_file(object $manifestcontents, string $tempfilepath,
                                                 string $manifestpath, string $moodleurl,
+                                                ?int $subcategoryid=null,
+                                                ?string $subdirectory=null,
                                                 bool $showupdated=true):object {
         // Read in temp file a question at a time, process and add to manifest.
         // No actual processing at the moment so could simplify to write straight
@@ -448,6 +452,8 @@ class cli_helper {
                     $manifestcontents->context->modulename = $questioninfo->modulename;
                     $manifestcontents->context->coursecategory = $questioninfo->coursecategory;
                     $manifestcontents->context->instanceid = $questioninfo->instanceid;
+                    $manifestcontents->context->defaultsubcategoryid = $subcategoryid;
+                    $manifestcontents->context->defaultsubdirectory = $subdirectory;
                     $manifestcontents->context->moodleurl = $moodleurl;
                 }
             }
@@ -636,9 +642,11 @@ class cli_helper {
      * is valid and then confirm with user it's the right one.
      *
      * @param object $activity
+     * @param boolean $defaultwarning If true, display using subcat default warning
+     * @param boolean $silent If true, don't display returned info
      * @return object
      */
-    public function check_context(object $activity):object {
+    public function check_context(object $activity, bool $defaultwarning=false, bool $silent=false):object {
         $activity->listpostsettings['contextonly'] = 1;
         $activity->listcurlrequest->set_option(CURLOPT_POSTFIELDS, $activity->listpostsettings);
         $response = $activity->listcurlrequest->execute();
@@ -656,7 +664,7 @@ class cli_helper {
             echo "Failed to get list of questions from Moodle.\n";
             static::call_exit();
             return new \stdClass(); // Required for PHPUnit.
-        } else {
+        } else if (!$silent) {
             $activityname = get_class($activity);
             echo "\nAbout to {$activityname}:\n";
             echo "Moodle URL: {$activity->moodleurl}\n";
@@ -667,9 +675,18 @@ class cli_helper {
             if ($moodlequestionlist->contextinfo->modulename) {
                 echo "{$moodlequestionlist->contextinfo->modulename}\n";
             }
-            echo "Question category: {$moodlequestionlist->contextinfo->qcategoryname}\n";
-            if (isset($activity->subdirectory) && $activity->subdirectory !== 'top') {
+            if (isset($activity->subdirectory)) {
                 echo "Question subdirectory: {$activity->subdirectory}\n";
+                if ($defaultwarning) {
+                    echo "Using default subdirectory from manifest file.\n";
+                    echo "Set --subdirectory to override.\n";
+                }
+            } else {
+                echo "Question category: {$moodlequestionlist->contextinfo->qcategoryname}\n";
+            }
+            if ($defaultwarning && !isset($activity->subdirectory)) {
+                echo "Using default question category from manifest file.\n";
+                echo "Set --subcategory or --questioncategoryid to override.\n";
             }
             static::handle_abort();
         }

--- a/classes/create_repo.php
+++ b/classes/create_repo.php
@@ -166,6 +166,7 @@ class create_repo {
         $this->listcurlrequest->set_option(CURLOPT_POST, 1);
         $this->listcurlrequest->set_option(CURLOPT_POSTFIELDS, $this->listpostsettings);
         $instanceinfo = $clihelper->check_context($this, false, false);
+        $this->subcategory = $instanceinfo->contextinfo->qcategoryname;
 
         $this->qcategoryid = $instanceinfo->contextinfo->qcategoryid;
         $this->listpostsettings['contextlevel'] =

--- a/classes/create_repo.php
+++ b/classes/create_repo.php
@@ -67,6 +67,12 @@ class create_repo {
      */
     public string $subcategory;
     /**
+     * Moodle id of question category.
+     *
+     * @var int|null
+     */
+    public ?int $qcategoryid = null;
+    /**
      * Path to actual manifest file.
      *
      * @var string
@@ -80,7 +86,7 @@ class create_repo {
     public string $tempfilepath;
     /**
      * Path of root of repo
-     * i.e. folder containing manifest
+     * i.e. folder containing manifest.
      *
      * @var string
      */
@@ -114,7 +120,7 @@ class create_repo {
         } else {
             $this->directory = $arguments['rootdirectory'];
         }
-        $this->subcategory = $arguments['subcategory'];
+        $this->subcategory = ($arguments['subcategory']) ? $arguments['subcategory'] : 'top';
         if (is_array($arguments['token'])) {
             $token = $arguments['token'][$moodleinstance];
         } else {
@@ -159,8 +165,9 @@ class create_repo {
         $this->listcurlrequest->set_option(CURLOPT_RETURNTRANSFER, true);
         $this->listcurlrequest->set_option(CURLOPT_POST, 1);
         $this->listcurlrequest->set_option(CURLOPT_POSTFIELDS, $this->listpostsettings);
-        $instanceinfo = $clihelper->check_context($this);
+        $instanceinfo = $clihelper->check_context($this, false, false);
 
+        $this->qcategoryid = $instanceinfo->contextinfo->qcategoryid;
         $this->listpostsettings['contextlevel'] =
                 cli_helper::get_context_level($instanceinfo->contextinfo->contextlevel);
         $this->listpostsettings['coursecategory'] = $instanceinfo->contextinfo->categoryname;
@@ -195,7 +202,8 @@ class create_repo {
         $this->manifestcontents->questions = [];
         $this->export_to_repo();
         cli_helper::create_manifest_file($this->manifestcontents, $this->tempfilepath,
-                                         $this->manifestpath, $this->moodleurl, false);
+                                         $this->manifestpath, $this->moodleurl,
+                                         $this->qcategoryid, $this->subdirectory, false);
         unlink($this->tempfilepath);
     }
 

--- a/classes/export_repo.php
+++ b/classes/export_repo.php
@@ -122,10 +122,10 @@ class export_repo {
         } else {
             if ($arguments['qcategoryid']) {
                 $qcategoryid = $arguments['qcategoryid'];
-             } else {
+            } else {
                 $qcategoryid = $this->manifestcontents->context->defaultsubcategoryid;
                 $defaultwarning = true;
-             }
+            }
             // Subcategory will be properly set later.
             $this->subcategory = 'top';
         }

--- a/classes/export_trait.php
+++ b/classes/export_trait.php
@@ -36,6 +36,12 @@ namespace qbank_gitsync;
  */
 trait export_trait {
     /**
+     * Relative path of subdirectory matching subcategory.
+     *
+     * @var string|null
+     */
+    public ?string $subdirectory = null;
+    /**
      * Obtain a list of questions from Moodle and loop through them.
      * If the question is not already in the manifest then create any necessary folders
      * and create the question file.
@@ -150,6 +156,9 @@ trait export_trait {
                         $currentdirectory = dirname($this->manifestpath) . $categorysofar;
                         if (!is_dir($currentdirectory)) {
                             mkdir($currentdirectory);
+                        }
+                        if ($categorypath === $this->subcategory) {
+                            $this->subdirectory = substr($categorysofar, 1);
                         }
                     }
                     $catfilepath = $currentdirectory . '/' . cli_helper::CATEGORY_FILE . '.xml';

--- a/classes/export_trait.php
+++ b/classes/export_trait.php
@@ -75,6 +75,7 @@ trait export_trait {
      * @return void
      */
     public function export_to_repo_main_process(object $moodlequestionlist):void {
+        $this->subdirectory = 'top';
         $questionsinmoodle = $moodlequestionlist->questions;
         $this->postsettings['includecategory'] = 1;
         $tempfile = fopen($this->tempfilepath, 'w+');

--- a/classes/external/get_question_list.php
+++ b/classes/external/get_question_list.php
@@ -73,7 +73,8 @@ class get_question_list extends external_api {
                 'coursename' => new external_value(PARAM_TEXT, 'course name (course or module context)'),
                 'modulename' => new external_value(PARAM_TEXT, 'module name (module context)'),
                 'instanceid' => new external_value(PARAM_SEQUENCE, 'id of course category, course or module'),
-                'qcategoryname' => new external_value(PARAM_TEXT, 'course category, course name and/or module'),
+                'qcategoryname' => new external_value(PARAM_TEXT, 'name of question category'),
+                'qcategoryid' => new external_value(PARAM_SEQUENCE, 'id of question category'),
             ]),
             'questions' => new external_multiple_structure(
                 new external_single_structure([
@@ -135,6 +136,7 @@ class get_question_list extends external_api {
         unset($response->contextinfo->context);
         $response->questions = [];
         $response->contextinfo->qcategoryname = '';
+        $response->contextinfo->qcategoryid = null;
 
         if (count($qbankentryids) === 1 && $qbankentryids[0] === '') {
             if (is_null($qcategoryid) || $qcategoryid === '') {
@@ -165,6 +167,7 @@ class get_question_list extends external_api {
             }
 
             $response->contextinfo->qcategoryname = self::get_category_path($category);
+            $response->contextinfo->qcategoryid = $category->id;
             if ($contextonly) {
                 return $response;
             }

--- a/cli/createrepo.php
+++ b/cli/createrepo.php
@@ -61,7 +61,7 @@ $options = [
         'longopt' => 'subcategory',
         'shortopt' => 's',
         'description' => 'Relative subcategory of question to actually export.',
-        'default' => 'top',
+        'default' => null,
         'variable' => 'subcategory',
         'valuerequired' => true,
     ],

--- a/cli/createrepo.php
+++ b/cli/createrepo.php
@@ -24,7 +24,7 @@
 
 namespace qbank_gitsync;
 define('CLI_SCRIPT', true);
-require_once('config.php');
+require_once('./config.php');
 require_once('../classes/curl_request.php');
 require_once('../classes/cli_helper.php');
 require_once('../classes/export_trait.php');

--- a/cli/deletefrommoodle.php
+++ b/cli/deletefrommoodle.php
@@ -69,7 +69,7 @@ $options = [
         'longopt' => 'subdirectory',
         'shortopt' => 's',
         'description' => 'Relative subdirectory of repo to actually delete from.',
-        'default' => 'top',
+        'default' => null,
         'variable' => 'subdirectory',
         'valuerequired' => true,
     ],

--- a/cli/exportrepofrommoodle.php
+++ b/cli/exportrepofrommoodle.php
@@ -61,7 +61,7 @@ $options = [
         'longopt' => 'subcategory',
         'shortopt' => 's',
         'description' => 'Relative subcategory of question to actually export.',
-        'default' => 'top',
+        'default' => null,
         'variable' => 'subcategory',
         'valuerequired' => true,
     ],

--- a/cli/importrepotomoodle.php
+++ b/cli/importrepotomoodle.php
@@ -69,7 +69,7 @@ $options = [
         'longopt' => 'subdirectory',
         'shortopt' => 's',
         'description' => 'Relative subdirectory of repo to actually import.',
-        'default' => 'top',
+        'default' => null,
         'variable' => 'subdirectory',
         'valuerequired' => true,
     ],

--- a/testrepo/fakeexport_system_question_manifest.json
+++ b/testrepo/fakeexport_system_question_manifest.json
@@ -5,7 +5,9 @@
         "modulename": "",
         "coursecategory": "",
         "qcategoryname": "/top",
-        "instanceid": ""
+        "instanceid": "",
+        "defaultsubdirectory": "top\/cat-2",
+        "defaultsubcategoryid": 5
     },
     "questions": [
         {

--- a/tests/cli_helper_test.php
+++ b/tests/cli_helper_test.php
@@ -265,7 +265,7 @@ class cli_helper_test extends advanced_testcase {
         $helper = new fake_cli_helper([]);
         $helper->processedoptions = ['token' => 'X', 'contextlevel' => 'system', 'subdirectory' => ''];
         $helper->validate_and_clean_args();
-        $this->assertEquals('top', $helper->processedoptions['subdirectory']);
+        $this->assertEquals(null, $helper->processedoptions['subdirectory']);
     }
 
     /**

--- a/tests/create_repo_test.php
+++ b/tests/create_repo_test.php
@@ -80,7 +80,7 @@ class create_repo_test extends advanced_testcase {
         $this->clihelper->expects($this->any())->method('get_arguments')->will($this->returnValue($this->options));
         $this->clihelper->expects($this->exactly(1))->method('check_context')->willReturn(
             json_decode('{"contextinfo":{"contextlevel": "module", "categoryname":"", "coursename":"Course 1",
-                             "modulename":"Module 1", "instanceid":"", "qcategoryname":"top"},
+                             "modulename":"Module 1", "instanceid":"", "qcategoryname":"top", "qcategoryid":1},
               "questions": []}')
         );
         // Mock call to webservice.
@@ -204,7 +204,8 @@ class create_repo_test extends advanced_testcase {
         $this->clihelper->expects($this->any())->method('get_arguments')->will($this->returnValue($this->options));
         $this->clihelper->expects($this->any())->method('check_context')->willReturn(
             json_decode('{"contextinfo":{"contextlevel": "module", "categoryname":"", "coursename":"Course 1",
-                             "modulename":"Module 1", "instanceid":"", "qcategoryname":"top/cat 2/subcat 2_1"},
+                             "modulename":"Module 1", "instanceid":"", "qcategoryname":"top/cat 2/subcat 2_1",
+                             "qcategoryid":1},
               "questions": []}')
         );
         $this->createrepo = $this->getMockBuilder(\qbank_gitsync\create_repo::class)->onlyMethods([

--- a/tests/create_repo_test.php
+++ b/tests/create_repo_test.php
@@ -250,4 +250,58 @@ class create_repo_test extends advanced_testcase {
         $this->assertEquals("top/Default-for-Test-1/sub-2", $manifest->context->defaultsubdirectory);
         $this->assertEquals(123, $manifest->context->defaultsubcategoryid);
     }
+
+    /**
+     * Test the full process with subcategoryid.
+     */
+    public function test_process_with_subcategory_id(): void {
+        $this->options['qcategoryid'] = 123;
+        $this->clihelper = $this->getMockBuilder(\qbank_gitsync\cli_helper::class)->onlyMethods([
+            'get_arguments', 'check_context',
+        ])->setConstructorArgs([[]])->getMock();
+        $this->clihelper->expects($this->any())->method('get_arguments')->will($this->returnValue($this->options));
+        $this->clihelper->expects($this->any())->method('check_context')->willReturn(
+            json_decode('{"contextinfo":{"contextlevel": "module", "categoryname":"", "coursename":"Course 1",
+                             "modulename":"Module 1", "instanceid":"", "qcategoryname":"top/Default for Test 1/sub 2",
+                             "qcategoryid":123},
+              "questions": []}')
+        );
+        $this->createrepo = $this->getMockBuilder(\qbank_gitsync\create_repo::class)->onlyMethods([
+            'get_curl_request', 'call_exit', 'handle_abort',
+        ])->setConstructorArgs([$this->clihelper, $this->moodleinstances])->getMock();
+
+        $this->createrepo->curlrequest = $this->curl;
+        $this->createrepo->listcurlrequest = $this->listcurl;
+
+        $this->listcurl->expects($this->exactly(1))->method('execute')->willReturn(
+            '{"contextinfo":{"contextlevel": "module", "categoryname":"", "coursename":"Course 1",
+                             "modulename":"Module 1", "instanceid":"", "qcategoryname":"top/Default for Test 1/sub 2"},
+              "questions": [{"questionbankentryid": "3", "name": "Three", "questioncategory": ""},
+                            {"questionbankentryid": "4", "name": "Four", "questioncategory": ""}]}'
+        );
+        $this->curl->expects($this->exactly(2))->method('execute')->willReturnOnConsecutiveCalls(
+            '{"question": "<quiz><question type=\"category\"><category><text>top/Default for Test 1/sub 2' .
+                          '</text></category></question><question><name><text>Three</text></name></question></quiz>"' .
+                          ', "version": "1"}',
+            '{"question": "<quiz><question type=\"category\"><category><text>top/Default for Test 1/sub 2' .
+                          '</text></category></question><question><name><text>Four</text></name></question></quiz>"' .
+                          ', "version": "1"}',
+        );
+        $this->createrepo->process($this->clihelper, $this->moodleinstances);
+
+        // Check question files exist.
+        $this->assertStringContainsString('Three', file_get_contents($this->rootpath . '/top/Default-for-Test-1/sub-2/Three.xml'));
+        $this->assertStringContainsString('Four', file_get_contents($this->rootpath . '/top/Default-for-Test-1/sub-2/Four.xml'));
+
+        // Check category files exist.
+        $this->assertStringContainsString('top/Default for Test 1/sub 2',
+                    file_get_contents($this->rootpath . '/top/Default-for-Test-1/sub-2/' . cli_helper::CATEGORY_FILE . '.xml'));
+        $this->assertStringContainsString('top/Default for Test 1/sub 2',
+                    file_get_contents($this->rootpath . '/top/Default-for-Test-1/sub-2/' . cli_helper::CATEGORY_FILE . '.xml'));
+
+        $this->expectOutputRegex('/^\nAdded 2 questions.\n$/s');
+        $manifest = $this->createrepo->manifestcontents;
+        $this->assertEquals("top/Default-for-Test-1/sub-2", $manifest->context->defaultsubdirectory);
+        $this->assertEquals(123, $manifest->context->defaultsubcategoryid);
+    }
 }

--- a/tests/export_repo_test.php
+++ b/tests/export_repo_test.php
@@ -118,6 +118,13 @@ class export_repo_test extends advanced_testcase {
         $this->exportrepo->postsettings = ['questionbankentryid' => null];
     }
 
+    /**
+     * Redo mock set up
+     *
+     * Required if we want to change options so that they affect contructor output.
+     *
+     * @return void
+     */
     public function replace_mock_default() {
         $this->clihelper = $this->getMockBuilder(\qbank_gitsync\cli_helper::class)->onlyMethods([
             'get_arguments', 'check_context',

--- a/tests/export_repo_test.php
+++ b/tests/export_repo_test.php
@@ -30,6 +30,30 @@ use advanced_testcase;
 use org\bovigo\vfs\vfsStream;
 
 /**
+ * Allows testing of errors that lead to an exit.
+ */
+class fake_export_cli_helper extends cli_helper {
+    /**
+     * Override so ignored during testing
+     *
+     * @return void
+     */
+    public static function call_exit():void {
+        return;
+    }
+
+    /**
+     * Override so ignored during testing
+     *
+     * @return void
+     */
+    public static function handle_abort():void {
+        return;
+    }
+}
+
+
+/**
  * Test the CLI script for exporting a repo from Moodle.
  * @group qbank_gitsync
  *
@@ -63,7 +87,7 @@ class export_repo_test extends advanced_testcase {
         $this->options = [
             'moodleinstance' => self::MOODLE,
             'rootdirectory' => $this->rootpath,
-            'subcategory' => 'top',
+            'subcategory' => null,
             'qcategoryid' => null,
             'manifestpath' => '/' . self::MOODLE . '_system' . cli_helper::MANIFEST_FILE,
             'token' => 'XXXXXX',
@@ -92,6 +116,24 @@ class export_repo_test extends advanced_testcase {
         $this->exportrepo->listcurlrequest = $this->listcurl;
 
         $this->exportrepo->postsettings = ['questionbankentryid' => null];
+    }
+
+    public function replace_mock_default() {
+        $this->clihelper = $this->getMockBuilder(\qbank_gitsync\cli_helper::class)->onlyMethods([
+            'get_arguments', 'check_context',
+        ])->setConstructorArgs([[]])->getMock();
+        $this->clihelper->expects($this->any())->method('get_arguments')->will($this->returnValue($this->options));
+        $this->clihelper->expects($this->any())->method('check_context')->willReturn(
+            json_decode('{"contextinfo":{"contextlevel": "module", "categoryname":"", "coursename":"Course 1",
+                             "modulename":"Module 1", "instanceid":"", "qcategoryname":"top/cat 2/subcat 2_1"},
+              "questions": []}')
+        );
+        $this->exportrepo = $this->getMockBuilder(\qbank_gitsync\export_repo::class)->onlyMethods([
+            'get_curl_request', 'call_exit', 'handle_abort',
+        ])->setConstructorArgs([$this->clihelper, $this->moodleinstances])->getMock();
+
+        $this->exportrepo->curlrequest = $this->curl;
+        $this->exportrepo->listcurlrequest = $this->listcurl;
     }
 
     /**
@@ -141,6 +183,8 @@ class export_repo_test extends advanced_testcase {
 
         $this->assertEquals('1', $existingentries['35001']->importedversion);
         $this->assertEquals('10', $existingentries['35001']->exportedversion);
+        // Question category id should be default from manifest.
+        $this->assertEquals(5, $this->exportrepo->listpostsettings["qcategoryid"]);
 
         $this->expectOutputRegex('/^\nExported 4 previously linked questions.*Added 0 questions.\n$/s');
     }
@@ -261,22 +305,7 @@ class export_repo_test extends advanced_testcase {
      */
     public function test_process_with_subcategory_name(): void {
         $this->options['subcategory'] = 'top/cat-2/subcat-2_1';
-        $this->clihelper = $this->getMockBuilder(\qbank_gitsync\cli_helper::class)->onlyMethods([
-            'get_arguments', 'check_context',
-        ])->setConstructorArgs([[]])->getMock();
-        $this->clihelper->expects($this->any())->method('get_arguments')->will($this->returnValue($this->options));
-        $this->clihelper->expects($this->any())->method('check_context')->willReturn(
-            json_decode('{"contextinfo":{"contextlevel": "module", "categoryname":"", "coursename":"Course 1",
-                             "modulename":"Module 1", "instanceid":"", "qcategoryname":"top/cat 2/subcat 2_1"},
-              "questions": []}')
-        );
-        $this->exportrepo = $this->getMockBuilder(\qbank_gitsync\export_repo::class)->onlyMethods([
-            'get_curl_request', 'call_exit', 'handle_abort',
-        ])->setConstructorArgs([$this->clihelper, $this->moodleinstances])->getMock();
-
-        $this->exportrepo->curlrequest = $this->curl;
-        $this->exportrepo->listcurlrequest = $this->listcurl;
-
+        $this->replace_mock_default();
         // Will get questions in order from manifest file in testrepo.
         $this->curl->expects($this->exactly(2))->method('execute')->willReturnOnConsecutiveCalls(
             '{"question": "<quiz><question><Name>Three</Name></question></quiz>", "version": "1"}',
@@ -313,6 +342,7 @@ class export_repo_test extends advanced_testcase {
         $this->assertArrayHasKey('35002', $existingentries);
         $this->assertArrayHasKey('35003', $existingentries);
         $this->assertArrayHasKey('35004', $existingentries);
+        $this->assertEquals(null, $this->exportrepo->listpostsettings["qcategoryid"]);
 
         $this->expectOutputRegex('/^\nExported 2 previously linked questions.*Added 0 questions.\n$/s');
     }
@@ -322,22 +352,8 @@ class export_repo_test extends advanced_testcase {
      */
     public function test_process_with_subcategory_id(): void {
         global $DB;
-        $this->options['qcategoryid'] = $DB->get_field('question_categories', 'id', ['name' => 'subcat 2_1']);
-        $this->clihelper = $this->getMockBuilder(\qbank_gitsync\cli_helper::class)->onlyMethods([
-            'get_arguments', 'check_context',
-        ])->setConstructorArgs([[]])->getMock();
-        $this->clihelper->expects($this->any())->method('get_arguments')->will($this->returnValue($this->options));
-        $this->clihelper->expects($this->any())->method('check_context')->willReturn(
-            json_decode('{"contextinfo":{"contextlevel": "module", "categoryname":"", "coursename":"Course 1",
-                             "modulename":"Module 1", "instanceid":"", "qcategoryname":"top/cat 2/subcat 2_1"},
-              "questions": []}')
-        );
-        $this->exportrepo = $this->getMockBuilder(\qbank_gitsync\export_repo::class)->onlyMethods([
-            'get_curl_request', 'call_exit', 'handle_abort',
-        ])->setConstructorArgs([$this->clihelper, $this->moodleinstances])->getMock();
-
-        $this->exportrepo->curlrequest = $this->curl;
-        $this->exportrepo->listcurlrequest = $this->listcurl;
+        $this->options['qcategoryid'] = 17;
+        $this->replace_mock_default();
 
         // Will get questions in order from manifest file in testrepo.
         $this->curl->expects($this->exactly(2))->method('execute')->willReturnOnConsecutiveCalls(
@@ -375,7 +391,25 @@ class export_repo_test extends advanced_testcase {
         $this->assertArrayHasKey('35002', $existingentries);
         $this->assertArrayHasKey('35003', $existingentries);
         $this->assertArrayHasKey('35004', $existingentries);
+        // Question category id should be as supplied.
+        $this->assertEquals(17, $this->exportrepo->listpostsettings["qcategoryid"]);
 
         $this->expectOutputRegex('/^\nExported 2 previously linked questions.*Added 0 questions.\n$/s');
     }
+
+    /**
+     * Test checking context default warning
+     * @covers \gitsync\cli_helper\check_context()
+     */
+    public function test_check_content_default_warning(): void {
+        $clihelper = new fake_export_cli_helper([]);
+        $this->listcurl->expects($this->exactly(1))->method('execute')->willReturn(
+            '{"contextinfo":{"contextlevel": "module", "categoryname":"", "coursename":"Course 1",
+                             "modulename":"Module 1", "instanceid":"", "qcategoryname":"top", "qcategoryid":1},
+              "questions": []}',
+        );
+        $clihelper->check_context($this->exportrepo, true, false);
+        $this->expectOutputRegex('/Using default question category from manifest file./');
+    }
+
 }

--- a/tests/export_trait_test.php
+++ b/tests/export_trait_test.php
@@ -63,7 +63,7 @@ class export_trait_test extends advanced_testcase {
         $this->options = [
             'moodleinstance' => self::MOODLE,
             'rootdirectory' => $this->rootpath,
-            'subcategory' => 'top',
+            'subcategory' => null,
             'qcategoryid' => null,
             'manifestpath' => '/' . self::MOODLE . '_system' . cli_helper::MANIFEST_FILE,
             'token' => 'XXXXXX',

--- a/tests/import_repo_test.php
+++ b/tests/import_repo_test.php
@@ -112,9 +112,9 @@ class import_repo_test extends advanced_testcase {
             'get_arguments', 'check_context',
         ])->setConstructorArgs([$this->options])->getMock();
         $this->clihelper->expects($this->any())->method('get_arguments')->will($this->returnValue($this->options));
-        $this->clihelper->expects($this->exactly(1))->method('check_context')->willReturn(
+        $this->clihelper->expects($this->any())->method('check_context')->willReturn(
             json_decode('{"contextinfo":{"contextlevel": "module", "categoryname":"", "coursename":"Course 1",
-                             "modulename":"Module 1", "instanceid":"", "qcategoryname":"top"},
+                             "modulename":"Module 1", "instanceid":"", "qcategoryname":"top", "qcategoryid":1},
               "questions": []}')
         );
         // Mock call to webservice.
@@ -486,7 +486,7 @@ class import_repo_test extends advanced_testcase {
 
         $this->importrepo->listcurlrequest->expects($this->exactly(1))->method('execute')->willReturn(
             '{"contextinfo":{"contextlevel": "module", "categoryname":"", "coursename":"Course 1",
-                "modulename":"Module 1", "instanceid":"", "qcategoryname":"top"},
+                "modulename":"Module 1", "instanceid":"", "qcategoryname":"top", "qcategoryid":1},
               "questions": []}'
         );
 
@@ -944,11 +944,11 @@ class import_repo_test extends advanced_testcase {
         $clihelper = new fake_helper([]);
         $this->listcurl->expects($this->exactly(1))->method('execute')->willReturn(
             '{"contextinfo":{"contextlevel": "module", "categoryname":"", "coursename":"Course 1",
-                             "modulename":"Module 1", "instanceid":"", "qcategoryname":"top"},
+                             "modulename":"Module 1", "instanceid":"", "qcategoryname":"top", "qcategoryid":1},
               "questions": []}',
         );
         $clihelper->check_context($this->importrepo);
-        $this->expectOutputRegex('/^\nAbout to.*import_repo.*Question category: top\n$/s');
+        $this->expectOutputRegex('/^\nAbout to.*import_repo.*Question subdirectory: top\n$/s');
     }
 
     /**

--- a/tests/import_repo_test.php
+++ b/tests/import_repo_test.php
@@ -140,6 +140,13 @@ class import_repo_test extends advanced_testcase {
         $this->importrepo->expects($this->any())->method('upload_file')->will($this->returnValue(true));
     }
 
+    /**
+     * Redo mock set up
+     *
+     * Required if we want to change options so that they affect contructor output.
+     *
+     * @return void
+     */
     public function replace_mock_default() {
         $this->clihelper = $this->getMockBuilder(\qbank_gitsync\cli_helper::class)->onlyMethods([
             'get_arguments', 'check_context',


### PR DESCRIPTION
- Default Subcategory id and Subdirectory path stored in manifest file on creation (either via createrepo or importrepo).
- Manifest defaults themselves default to 'top' for the path and the matching category id obtained from Moodle if no subcategory/subdirectory supplied to the script creating the manifest.
- Manifest defaults used on subsequent exports, and on imports where manifest file parameter used.
- Manifest default overridden by using subcategory name or id on export, or subdirectory path on import. 