### PR TITLE
Bug fix - questions with matching names

### DIFF
--- a/README.md
+++ b/README.md
@@ -65,8 +65,41 @@ There are two logically separate parts of this project.
 
 This project provides tools which scan the files on the external file system, and maintains the manifest file to match the file system and the Moodle question bank. Questions added or removed from the file system (via `git add`, `git rm` or through consequences of a `git pull` from an external repro) will be reflected in the manifest file but not necessarily straight away. The manifest file does not record what is in the repo - the file system itself does that. The manifest file links questions in the file system to questions in a Moodle instance. The manifest is tidied as appropriate on import/export. See [process details](doc/processdetails.md) document for exactly what happens when.
 
-By default, the manifest file is not stored as part of the Git repo but is only on the user's local computer. This allows repos to be shared with other users using different Moodle instances. For repos tied to a single Moodle instance adding the manifest to the repo may be useful.
+By default, the manifest file is not stored as part of the Git repo but is only on the user's local computer. This allows repos to be shared with other users using different Moodle instances. For repos tied to a single Moodle instance adding the manifest to the repo may be useful (but users will need to be careful to use the same Moodle instance short names in their config file).
 
+A manifest file will have the name `instancename_contextlevel_contextname_question_manifest.json` and look like this:
+```
+"context": {
+        "contextlevel": 50, // Moodle context code e.g. 50 === 'course'
+        "coursename": "Course 1", // Context details required are dependent on contextlevel
+        "modulename": null, // Restricted to quiz modules
+        "coursecategory": null,
+        "instanceid": "2", // Course, coursecategory or quiz id
+        "defaultsubcategoryid": 3, // Set by the subcategory/directory used at manifest creation
+        "defaultsubdirectory": "top", // Set by the subcategory/directory used at manifest creation
+        "moodleurl": "http:\/\/stack.stack.virtualbox.org\/edmundlocal"
+    },
+    "questions": [
+        {
+            "questionbankentryid": "727",
+            "filepath": "\/top\/Default-for-T1\/Slope-of-line.xml", // Relative to top of the repository
+            "format": "xml", // Currently always XML
+            "importedversion": "1", // Question version in Moodle on manifest creation or after last import
+            "exportedversion": "1", // Question version last exported from Moodle
+            "currentcommit": "371a103f2465319494c69500a84626a9d19e75f8", // Current Git hash of question file
+            "moodlecommit": "371a103f2465319494c69500a84626a9d19e75f8" // Git hash of file when last imported into Moodle
+        },
+        {
+            "questionbankentryid": "728",
+            "filepath": "\/top\/Default-for-T1\/Equations-of-straight-lines.xml",
+            "format": "xml",
+            "importedversion": "11",
+            "exportedversion": "11",
+            "currentcommit": "371a103f2465319494c69500a84626a9d19e75f8",
+            "moodlecommit": "371a103f2465319494c69500a84626a9d19e75f8"
+        }
+    ]
+```
 # Setup
 
 Gitsync is run from and stores question files on your local computer not on the Moodle server. First you need to install it and set it up as a plugin within Moodle and then you need to download and set it up locally.

--- a/classes/export_trait.php
+++ b/classes/export_trait.php
@@ -187,6 +187,12 @@ trait export_trait {
                     }
                 }
                 $sanitisedqname = preg_replace(cli_helper::BAD_CHARACTERS, '-', substr($qname, 0, 230));
+                $holdername = $sanitisedqname;
+                $i = 2;
+                while (file_exists("{$bottomdirectory}/{$sanitisedqname}.xml")) {
+                    $sanitisedqname = "{$holdername}_{$i}";
+                    $i++;
+                }
                 $success = file_put_contents("{$bottomdirectory}/{$sanitisedqname}.xml", $question);
                 if ($success === false) {
                     echo "\nFile creation or update unsuccessful:\n";

--- a/classes/external/get_question_list.php
+++ b/classes/external/get_question_list.php
@@ -163,7 +163,11 @@ class get_question_list extends external_api {
             }
 
             if (!$category) {
-                throw new \moodle_exception('categoryerror', 'qbank_gitsync', null, $params['qcategoryname']);
+                if ($params['qcategoryname'] === 'top') {
+                    throw new \moodle_exception('categoryerrornew', 'qbank_gitsync', null, $params['qcategoryname']);
+                } else {
+                    throw new \moodle_exception('categoryerror', 'qbank_gitsync', null, $params['qcategoryname']);
+                }
             }
 
             $response->contextinfo->qcategoryname = self::get_category_path($category);

--- a/cli/config_sample.txt
+++ b/cli/config_sample.txt
@@ -23,7 +23,9 @@
  */
 
 // Array of moodleinstnce nicknames and URLs.
-// The nicknames are used how....
+// The nicknames are used in manifest file names and as a shorthand for which
+// instance to use when running scripts. Users sharing a manifest file should
+// use the same instance nickname.
 // No trailing slash on the URLs.
 $moodleinstances = [
     'instance1' => 'http://stack.org/instance1',

--- a/cli/config_sample.txt
+++ b/cli/config_sample.txt
@@ -44,7 +44,6 @@ $instance = 'instance1';
 // Root directory on the local file system.
 // This directory stores all git repos associated with the gitsync.
 // No trailing slash on the directory name.
-// Windows users must change backslash \ to forward slash /.
 $rootdirectory = '/home/user/questions';
 
 // You can set a default manifest file path for import, export and delete.

--- a/lang/en/qbank_gitsync.php
+++ b/lang/en/qbank_gitsync.php
@@ -35,4 +35,5 @@ $string['importversionerror'] = 'Could not import question : {$a->name} Current 
 $string['noquestionerror'] = 'Question does not exist. Questionbankentryid: {$a}';
 $string['contexterror'] = 'The context level is invalid: {$a}';
 $string['categoryerror'] = 'Problem with question category: {$a}';
+$string['categoryerrornew'] = 'Problem with question category: {$a}. If the course is new, please open the question bank in Moodle to initialise it and try Gitsync again.';
 $string['categorymismatcherror'] = 'Problem with question category: {$a}. The category is not in the supplied context.';

--- a/tests/export_trait_test.php
+++ b/tests/export_trait_test.php
@@ -120,10 +120,48 @@ class export_trait_test extends advanced_testcase {
         $this->listcurl->expects($this->exactly(1))->method('execute')->willReturnOnConsecutiveCalls(
             '{"contextinfo":{"contextlevel": "module", "categoryname":"", "coursename":"Course 1",
                 "modulename":"Module 1", "instanceid":"", "qcategoryname":"top"},
-              "questions": [{"questionbankentryid": "5", "name": "Fifth Question", "questioncategory": "subcat 2_1"},
-              {"questionbankentryid": "6", "name": "Fifth Question", "questioncategory": "cat 3"},
-              {"questionbankentryid": "7", "name": "Fifth Question", "questioncategory": "cat 3"},
-              {"questionbankentryid": "8", "name": "Fifth Question", "questioncategory": "subcat 2_1"}]}'
+              "questions": [{"questionbankentryid": "5", "name": "Five", "questioncategory": "subcat 2_1"},
+              {"questionbankentryid": "6", "name": "Six", "questioncategory": "cat 3"},
+              {"questionbankentryid": "7", "name": "Seven", "questioncategory": "cat 3"},
+              {"questionbankentryid": "8", "name": "Eight", "questioncategory": "subcat 2_1"}]}'
+        );
+    }
+
+    /**
+     * Set valid output for web service calls with questions with matching names.
+     *
+     * @return void
+     */
+    public function set_curl_output_same_name():void {
+        $this->curl->expects($this->exactly(5))->method('execute')->willReturnOnConsecutiveCalls(
+            '{"question": "<quiz><question type=\"category\"><category>' .
+                          '<text>top/Source 2/cat 2/subcat 2_1</text></category></question>' .
+                          '<question><name><text>Five</text></name></question></quiz>", "version": "10"}',
+            '{"question": "<quiz><question type=\"category\"><category><text>top/Source 2/cat 3</text></category></question>' .
+                          '<question><name><text>Five</text></name></question></quiz>"' .
+                          ', "version": "1"}',
+            '{"question": "<quiz><question type=\"category\"><category><text>top/Source 2</text></category></question>' .
+                          '<question type=\"category\"><category><text>top/Source 2/cat 3</text></category></question>' .
+                          '<question><name><text>Five</text></name></question></quiz>"' .
+                          ', "version": "1"}',
+            '{"question": "<quiz><question type=\"category\"><category><text>top/Source 2/cat 2</text></category></question>' .
+                          '<question type=\"category\"><category><text>top/Source 2/cat 2/subcat 2_1</text></category></question>' .
+                          '<question><name><text>Five</text></name></question></quiz>"' .
+                          ', "version": "1"}',
+            '{"question": "<quiz><question type=\"category\"><category><text>top/Source 2/cat 2</text></category></question>' .
+                          '<question type=\"category\"><category><text>top/Source 2/cat 2/subcat 2_1</text></category></question>' .
+                          '<question><name><text>Five</text></name></question></quiz>"' .
+                          ', "version": "1"}',
+        );
+
+        $this->listcurl->expects($this->exactly(1))->method('execute')->willReturnOnConsecutiveCalls(
+            '{"contextinfo":{"contextlevel": "module", "categoryname":"", "coursename":"Course 1",
+                "modulename":"Module 1", "instanceid":"", "qcategoryname":"top"},
+              "questions": [{"questionbankentryid": "5", "name": "Five", "questioncategory": "subcat 2_1"},
+              {"questionbankentryid": "6", "name": "Five", "questioncategory": "cat 3"},
+              {"questionbankentryid": "7", "name": "Five", "questioncategory": "cat 3"},
+              {"questionbankentryid": "8", "name": "Five", "questioncategory": "subcat 2_1"},
+              {"questionbankentryid": "9", "name": "Five", "questioncategory": "subcat 2_1"}]}'
         );
     }
 
@@ -235,42 +273,23 @@ class export_trait_test extends advanced_testcase {
     }
 
     /**
-     * Test message if question file update issue.
-     */
-    public function test_question_file_update_error(): void {
-        $questions = json_decode('{"contextinfo":{"contextlevel": "module", "categoryname":"", "coursename":"Course 1",
-                                "modulename":"Module 1", "instanceid":"", "qcategoryname":"top"},
-                                "questions": [{"questionbankentryid": "5", "name": "Third Question",
-                                "questioncategory": "subcat 2_1"}]}');
-        $this->curl->expects($this->exactly(1))->method('execute')->willReturnOnConsecutiveCalls(
-            '{"question": "<quiz><question type=\"category\"><category>' .
-                          '<text>top/cat 2/subcat 2_1</text></category></question>' .
-                          '<question><name><text>Third Question</text></name></question></quiz>", "version": "10"}',
-        );
-
-        chmod($this->rootpath . '/top/cat-2/subcat-2_1/Third-Question.xml', 0000);
-        @$this->exportrepo->export_to_repo_main_process($questions);
-        $this->expectOutputRegex('/^\nFile creation or update unsuccessful:.*Third-Question.xml$/s');
-    }
-
-    /**
      * Test message if category file creation issue.
      */
     public function test_category_file_creation_error(): void {
         $questions = json_decode('{"contextinfo":{"contextlevel": "module", "categoryname":"", "coursename":"Course 1",
                                 "modulename":"Module 1", "instanceid":"", "qcategoryname":"top"},
-                                "questions": [{"questionbankentryid": "5", "name": "Third Question",
+                                "questions": [{"questionbankentryid": "5", "name": "Another Question",
                                 "questioncategory": "subcat 2_1"}]}');
         $this->curl->expects($this->exactly(1))->method('execute')->willReturnOnConsecutiveCalls(
             '{"question": "<quiz><question type=\"category\"><category>' .
                           '<text>top/cat 2/subcat 2_1</text></category></question>' .
-                          '<question><name><text>Third Question</text></name></question></quiz>", "version": "10"}',
+                          '<question><name><text>Another Question</text></name></question></quiz>", "version": "10"}',
         );
 
         unlink($this->rootpath . '/top/cat-2/subcat-2_1/' . cli_helper::CATEGORY_FILE . '.xml');
         chmod($this->rootpath . '/top/cat-2/subcat-2_1', 0000);
         @$this->exportrepo->export_to_repo_main_process($questions);
-        $this->expectOutputRegex('/^\nFile creation unsuccessful:.*subcat-2_1\/' . cli_helper::CATEGORY_FILE . '.xml$/s');
+        $this->expectOutputRegex('/^\nFile creation unsuccessful:.*subcat-2_1\/' . cli_helper::CATEGORY_FILE . '.xml.*$/s');
     }
 
     /**
@@ -289,5 +308,30 @@ class export_trait_test extends advanced_testcase {
 
         @$this->exportrepo->export_to_repo_main_process($questions);
         $this->expectOutputRegex('/^\nBroken XML.\nsubcat 2_1 - Third Question not downloaded.\n$/s');
+    }
+
+    /**
+     * Test the export of questions which aren't in the manifest and have the same name
+     * @covers \gitsync\export_trait\export_to_repo()
+     */
+    public function test_export_to_repo_same_name(): void {
+        $this->set_curl_output_same_name();
+        $this->exportrepo->export_to_repo();
+
+        // Check question files created.
+        $this->assertStringContainsString('Five', file_get_contents($this->rootpath . '/top/Source-2/cat-2/subcat-2_1/Five.xml'));
+        $this->assertStringContainsString('Five', file_get_contents($this->rootpath . '/top/Source-2/cat-2/subcat-2_1/Five_2.xml'));
+        $this->assertStringContainsString('Five', file_get_contents($this->rootpath . '/top/Source-2/cat-2/subcat-2_1/Five_3.xml'));
+        $this->assertStringContainsString('top/Source 2/cat 3',
+            file_get_contents($this->rootpath . '/top/Source-2/cat-3/' . cli_helper::CATEGORY_FILE . '.xml'));
+        $this->assertStringContainsString('Five', file_get_contents($this->rootpath . '/top/Source-2/cat-3/Five.xml'));
+        $this->assertStringContainsString('Five', file_get_contents($this->rootpath . '/top/Source-2/cat-3/Five_2.xml'));
+
+        // Check temp file.
+        $tempfile = fopen($this->exportrepo->tempfilepath, 'r');
+        $firstline = json_decode(fgets($tempfile));
+        $this->assertEquals('5', $firstline->questionbankentryid);
+        $this->assertEquals($this->rootpath . '/top/Source-2/cat-2/subcat-2_1/Five.xml', $firstline->filepath);
+        $this->assertEquals($firstline->version, '10');
     }
 }


### PR DESCRIPTION
Questions with the same name and location were over-writing each other on export as they had the same file name.
Underscore and increasing numbers now added to the file name if the question is not in the manifest but a file already exists.