### PR TITLE
Iss60 - Moodle 5 Compatibility

### DIFF
--- a/.github/workflows/moodle-ci.yml
+++ b/.github/workflows/moodle-ci.yml
@@ -31,8 +31,11 @@ jobs:
       fail-fast: false
       matrix: # I don't know why, but mariadb is much slower, so mostly use pgsql.
         include:
-          - php: '8.2'
+          - php: '8.3'
             moodle-branch: 'main'
+            database: 'pgsql'
+          - php: '8.2'
+            moodle-branch: 'MOODLE_500_STABLE'
             database: 'pgsql'
           - php: '8.2'
             moodle-branch: 'MOODLE_405_STABLE'

--- a/.github/workflows/moodle-ci.yml
+++ b/.github/workflows/moodle-ci.yml
@@ -73,7 +73,7 @@ jobs:
 
       - name: Initialise moodle-plugin-ci
         run: |
-          composer create-project -n --no-dev --prefer-dist moodlehq/moodle-plugin-ci ci ^3
+          composer create-project -n --no-dev --prefer-dist moodlehq/moodle-plugin-ci ci ^4
           echo $(cd ci/bin; pwd) >> $GITHUB_PATH
           echo $(cd ci/vendor/bin; pwd) >> $GITHUB_PATH
           sudo locale-gen en_AU.UTF-8

--- a/classes/cli_helper.php
+++ b/classes/cli_helper.php
@@ -787,7 +787,7 @@ class cli_helper {
                 echo "Course: {$moodlequestionlist->contextinfo->coursename}\n";
             }
             if ($moodlequestionlist->contextinfo->modulename) {
-                echo "Quiz: {$moodlequestionlist->contextinfo->modulename}\n";
+                echo "Module: {$moodlequestionlist->contextinfo->modulename}\n";
             }
             if (isset($activity->ignorecat)) {
                 echo "Ignoring categories (and their descendants) in form: {$activity->ignorecat}\n";

--- a/classes/external/get_question_list.php
+++ b/classes/external/get_question_list.php
@@ -197,7 +197,7 @@ class get_question_list extends external_api {
             $response->contextinfo->qcategoryname = self::get_category_path($category);
             $response->contextinfo->qcategoryid = $category->id;
 
-            if ((int) $params['contextlevel'] === \CONTEXT_COURSE) {
+            if ((int) $params['contextlevel'] === \CONTEXT_COURSE || (int) $params['contextlevel'] === \CONTEXT_MODULE) {
                 $response->quizzes = $DB->get_records_sql(
                     "SELECT cm.id as instanceid, q.name
                         FROM {course_modules} cm
@@ -206,7 +206,7 @@ class get_question_list extends external_api {
                     WHERE cm.course = :courseid
                         AND m.name = 'quiz'
                         AND cm.deletioninprogress = 0",
-                    ['courseid' => (int) $contextinfo->instanceid]);
+                    ['courseid' => (int) $contextinfo->courseid]);
             }
 
             if ($contextonly) {

--- a/classes/external/import_quiz_data.php
+++ b/classes/external/import_quiz_data.php
@@ -237,7 +237,17 @@ class import_quiz_data extends external_api {
             }
         } else {
             $quizcontext = get_context(\CONTEXT_MODULE, null, null, null, $moduleinfo->coursemodule);
-            \question_make_default_categories([$quizcontext->context]);
+            if (function_exists('question_get_default_category')) {
+                // This function exists from Moodle 4.5 onwards but the second parameter
+                // which creates the category if it doesn't exist is 5.0 onwards.
+                $topcategory = question_get_default_category($quizcontext->context->id, true);
+                if (!$topcategory) {
+                    \question_make_default_categories([$quizcontext->context]);
+                }
+            } else {
+                // Deprecated from 5.0.
+                \question_make_default_categories([$quizcontext->context]);
+            }
         }
 
         foreach ($params['feedback'] as $feedback) {

--- a/classes/import_quiz.php
+++ b/classes/import_quiz.php
@@ -142,7 +142,7 @@ class import_quiz {
         $moodleinstance = $arguments['moodleinstance'];
         $this->moodleurl = $moodleinstances[$moodleinstance];
         $instanceid = $arguments['instanceid'];
-        $contextlevel = 50;
+        $contextlevel = cli_helper::get_context_level('course');
         $this->usegit = $arguments['usegit'];
         if (!empty($arguments['quizmanifestpath'])) {
             $this->quizmanifestpath = ($arguments['quizmanifestpath']) ?
@@ -162,7 +162,7 @@ class import_quiz {
                                                                                 dirname($this->quizmanifestpath));
                 $instanceid = $this->cmid;
                 $coursename = '';
-                $contextlevel = 70;
+                $contextlevel = cli_helper::get_context_level('module');
             }
         } else {
             if ($arguments['quizdatapath']) {
@@ -203,8 +203,11 @@ class import_quiz {
                 echo "\nManifest file is for the wrong Moodle instance: {$this->nonquizmanifestpath}\nAborting.\n";
                 $this->call_exit();
             }
-            if (!$instanceid && $this->nonquizmanifestcontents->context->contextlevel === cli_helper::get_context_level('course')) {
+            if (!$instanceid) {
                 $instanceid = $this->nonquizmanifestcontents->context->instanceid;
+            }
+            if ($this->nonquizmanifestcontents->context->contextlevel === cli_helper::get_context_level('module')) {
+                $contextlevel = cli_helper::get_context_level('module');
             }
         }
         if (!$instanceid && !$arguments['coursename'] && !$this->quizmanifestcontents) {

--- a/cli/createwholecourserepo.php
+++ b/cli/createwholecourserepo.php
@@ -65,7 +65,8 @@ $options = [
     [
         'longopt' => 'contextlevel',
         'shortopt' => 'l',
-        'description' => 'Context from which to extract questions. Should always be module for Moodle 5+. Should always be course for Moodle < 5.',
+        'description' => 'Context from which to extract questions. Should always be module for Moodle 5+. ' .
+                         'Should always be course for Moodle < 5.',
         'default' => 'course',
         'variable' => 'contextlevel',
         'valuerequired' => true,

--- a/cli/createwholecourserepo.php
+++ b/cli/createwholecourserepo.php
@@ -65,11 +65,10 @@ $options = [
     [
         'longopt' => 'contextlevel',
         'shortopt' => 'l',
-        'description' => 'Context from which to extract questions. Should always be course.',
+        'description' => 'Context from which to extract questions. Should always be module for Moodle 5+. Should always be course for Moodle < 5.',
         'default' => 'course',
         'variable' => 'contextlevel',
         'valuerequired' => true,
-        'hidden' => true,
     ],
     [
         'longopt' => 'subcategory',
@@ -98,7 +97,7 @@ $options = [
     [
         'longopt' => 'instanceid',
         'shortopt' => 'n',
-        'description' => 'Numerical id of the course, module of course category.',
+        'description' => 'Numerical id of the course or question bank module.',
         'default' => null,
         'variable' => 'instanceid',
         'valuerequired' => true,

--- a/cli/importwholecoursetomoodle.php
+++ b/cli/importwholecoursetomoodle.php
@@ -76,7 +76,8 @@ $options = [
     [
         'longopt' => 'contextlevel',
         'shortopt' => 'l',
-        'description' => 'Context to import questions into. Should always be module for Moodle 5+. Should always be course for Moodle < 5.',
+        'description' => 'Context to import questions into. Should always be module for Moodle 5+. ' .
+                         'Should always be course for Moodle < 5.',
         'default' => null,
         'variable' => 'contextlevel',
         'valuerequired' => true,

--- a/cli/importwholecoursetomoodle.php
+++ b/cli/importwholecoursetomoodle.php
@@ -76,7 +76,7 @@ $options = [
     [
         'longopt' => 'contextlevel',
         'shortopt' => 'l',
-        'description' => 'Context from which to extract questions. Should always be course.',
+        'description' => 'Context to import questions into. Should always be module for Moodle 5+. Should always be course for Moodle < 5.',
         'default' => null,
         'variable' => 'contextlevel',
         'valuerequired' => true,
@@ -92,7 +92,7 @@ $options = [
     [
         'longopt' => 'modulename',
         'shortopt' => 'm',
-        'description' => 'Not used',
+        'description' => 'Name of the question bank module',
         'default' => null,
         'variable' => 'modulename',
         'valuerequired' => true,
@@ -110,7 +110,7 @@ $options = [
     [
         'longopt' => 'instanceid',
         'shortopt' => 'n',
-        'description' => 'Numerical id of the course.',
+        'description' => 'Numerical id of the course or module.',
         'default' => null,
         'variable' => 'instanceid',
         'valuerequired' => true,

--- a/doc/createrepo.md
+++ b/doc/createrepo.md
@@ -26,6 +26,10 @@
 |h|help|
 |x|ignorecat|Regex of categories to ignore - add an extra leading / for Windows.
 
+For Moodle 5+, there are no longer course, course category or system context question banks. Questions are contained in module level question banks. This makes things simpler. Where command line parameters for `contextlevel` and `instanceid` are required you will always need to use `module` and the value of `cmid` from the URL of the question bank.
+
+e.g. `php createrepo.php -l module -n 2 -d "master"`
+
 ### Example 1:
 
 Assume you have correct information in config.php, i.e. the Moodle URL in `$moodleinstances`, and the webservice token stored in `$token`, the default moodle instance in `$instance` and the local root directory for your question files in `$rootdirectory`.

--- a/doc/createwholecourserepo.md
+++ b/doc/createwholecourserepo.md
@@ -37,7 +37,7 @@ Create and initialise the "scratch-wholecourse" directory using `git init scratc
 
 Along with the "scratch-course" directory, there should be a directory created by the script for each of the quizzes with names in the format "scratch-course_quiz_sanitised-quiz-name".
 
-For Moodle 5+, there is no longer a course context question bank. Questions are contained in module level question banks. GitSync can be made to treat a course with a single question bank like an old course, however. Add `-l "module"` to the command line parameters and `cmid` from the URL of the question bank as `--instanceid`.
+For Moodle 5+, there is no longer a course context question bank. Questions are contained in module level question banks. Gitsync can be made to treat a course with a single question bank like an old course, however. Add `-l "module"` to the command line parameters and `cmid` from the URL of the question bank as `--instanceid`.
 
 `php createwholecourserepo.php -l 'module' -n 7 -d 'moodle-5/scratch-course'`
 

--- a/doc/createwholecourserepo.md
+++ b/doc/createwholecourserepo.md
@@ -12,10 +12,11 @@
 |i|moodleinstance|Key of Moodle instance in $moodleinstances to use. Should match end of instance URL.|
 |r|rootdirectory|Directory on user's computer containing repos.|
 |d|directory|Directory of repo on user's computer containing "top" folder, relative to root directory.|
+|l|contextlevel|Context from which to extract questions. Should always be module for Moodle 5+. Should always be course for Moodle < 5.|
 |s|subcategory|Relative subcategory of repo to actually export.|
 |c|coursename|Unique course name for course or module context.
 |q|questioncategoryid|Numerical id of subcategory to actually export.
-|n|instanceid|Numerical id of the course category.
+|n|instanceid|Numerical id of the course.
 |t|token|Security token for webservice.
 |h|help|
 |x|ignorecat|Regex of categories to ignore - add an extra leading / for Windows.
@@ -35,6 +36,10 @@ Create and initialise the "scratch-wholecourse" directory using `git init scratc
 `php createwholecourserepo.php -c "Scratch" -d "scratch-wholecourse/scratch-course" `
 
 Along with the "scratch-course" directory, there should be a directory created by the script for each of the quizzes with names in the format "scratch-course_quiz_sanitised-quiz-name".
+
+For Moodle 5+, there is no longer a course context question bank. Questions are contained in module level question banks. GitSync can be made to treat a course with a single question bank like an old course, however. Add `-l "module"` to the command line parameters and `cmid` from the URL of the question bank as `--instanceid`.
+
+`php createwholecourserepo.php -l 'module' -n 7 -d 'moodle-5/scratch-course'`
 
 ### On failure
 

--- a/doc/importwholecoursetomoodle.md
+++ b/doc/importwholecoursetomoodle.md
@@ -36,10 +36,21 @@ To update the questions in Moodle from the repo, point the script to your course
 `php importrepotomoodle.php -f "scratch-wholecourse/scratch-course"`
 
 Example 2:
-To import course context questions, quiz context questions and quiz structures into a course for the first time, you will need to point the script to the course directory and the course to import into (using either coursename -c or id -n). You will also need to specify context level but this will always be course (`-l "course"`).
+To import course context questions, quiz context questions and quiz structures into a course for the first time, you will need to point the script to the course directory and the course to import into (using either coursename -c or id -n). You will also need to specify context level but this will always be course (`-l "course"`) for Moodle 4 and (`-l "module"`) for Moodle 5+.
+
 `php importwholecoursetomoodle.php -r "C:\question_repos" -d "scratch-wholecourse/scratch-course" -l "course" -c "Course 2"`
 
-## Scenario 1: Importing questions into Moodle from an existing repo
+## Scenario 1: Re-importing questions into Moodle when the manifest files already exist
+
+You should specify the course manifest file path and context will be extracted from that. You can still enter a subdirectory to only re-import some of the questions.
+
+Import will only be possible if there are not updates to the questions in Moodle which haven't been exported.
+
+Only questions that have changed in the repo since the last import will be imported to Moodle (to avoid creating a new version in Moodle when nothing has changed).
+
+Quiz structure will not be updated.
+
+## Scenario 2: Importing questions into Moodle from an existing repo
 
 e.g. You have exported questions from one Moodle instance to create the repo and you want to import them into a different instance
 
@@ -49,15 +60,9 @@ You will need to specify the course you want to import the questions and quizzes
 
 If you only want to import a certain question category (and its subcategories) within the course you will need to supply the path of the corresponding folder within your repo relative to the 'top' category e.g. 'category-1/subcategory-2'.
 
-## Scenario 2: Re-importing questions into Moodle when the manifest files already exist
+For Moodle 5+, there is no longer a course context question bank. Questions are contained in module level question banks. Gitsync can be made to treat a course with a single question bank like an old course, however. Add `-l "module"` to the command line parameters and `cmid` from the URL of the question bank as `--instanceid` or `-n`.
 
-You should specify the course manifest file path and context will be extracted from that. You can still enter a subdirectory to only re-import some of the questions.
-
-Import will only be possible if there are not updates to the questions in Moodle which haven't been exported.
-
-Only questions that have changed in the repo since the last import will be imported to Moodle (to avoid creating a new version in Moodle when nothing has changed).
-
-Quiz structure will not be updated.
+`php importwholecoursetomoodle.php -l 'module' -n 7 -d 'moodle-5/scratch-course'`
 
 ## Deletion
 

--- a/doc/usinggit.md
+++ b/doc/usinggit.md
@@ -210,13 +210,22 @@ Initialise a repo for course and quizzes together:
 `git init course1whole`  
 Export course with `id=3` into directory `course1` (assuming rootdirectory, token, moodleinstance, usegit, etc, all set in your config file.):  
 `php createwholecourserepo.php -n 3 -d 'course1whole/course1'`  
+(Moodle 5+ with course question bank `cmid=7`: `php createwholecourserepo.php -l 'module' -n 7 -d 'course1whole/course1'`)  
 Export questions/structures again after updates in Moodle:  
 `php exportwholecoursefrommoodle.php -f 'course1whole/course1/instance1_course_course-1_question_manifest.json'`  
 Import questions again after updates in the repo:  
 `php importwholecoursetomoodle.php -f 'course1whole/course1/instance1_course_course-1_question_manifest.json'`  
 Import course questions and quizzes into course with `id=2`:  
 `php importwholecoursetomoodle.php -d 'course1whole/course1' -l 'course' -n 2`  
+(Moodle 5+ into course question bank `cmid=9`: `php importwholecoursetomoodle.php -d 'course1whole/course1' -l 'module' -n 9`)
 
 You can use the normal filters like subcategory and ignorecategory e.g.:  
 `php createwholecourserepo.php -n 3 -d 'course1whole/course1' -x '/subcat/'`  
 `php importwholecoursetomoodle.php -f 'course1whole/course1/instance1_course_course-1_question_manifest.json' -x '/subcat/'`
+
+For Moodle 5+, there is no longer a course context question bank. Questions are contained in module level question banks. Gitsync can be made to treat a course with a single question bank like an old course, however. Add `-l "module"` to the command line parameters and `cmid` from the URL of the question bank as `--instanceid` when creating the repo or importing into a new course.
+
+`php createwholecourserepo.php -l 'module' -n 7 -d 'course1whole/course1'`  
+`php importwholecoursetomoodle.php -l 'module' -n 9 -d 'course1whole/course1'`
+
+It is recommended that you do not use Gitsync with courses that have multiple question banks.

--- a/doc/usinggit.md
+++ b/doc/usinggit.md
@@ -15,6 +15,12 @@ If you want to track a course and all its quizzes in a single repo, you will nee
 
 (See [Quizzes](#quizzes).)
 
+# Moodle 5 update
+
+For Moodle 5+, there are no longer course, course category or system context question banks. Questions are contained in module level question banks. This makes things simpler. Where command line parameters for `contextlevel` and `instanceid` are required you will always need to use `module` and the value of `cmid` from the URL of the question bank.
+
+e.g. `php createrepo.php -l module -n 2 -d "master"`
+
 ## Maintaining a one-to-one link between a Moodle instance and a Git repo
 
 ### Creating a Git repo from questions in Moodle

--- a/lib.php
+++ b/lib.php
@@ -100,17 +100,17 @@ function get_context(int $contextlevel, ?string $categoryname = null,
             return $result;
         case \CONTEXT_MODULE:
             if (is_null($instanceid)) {
-                // Assuming here that the module is a quiz.
+                // Assuming here that the module is a quiz or question bank.
                 $instancedata = $DB->get_record_sql("
                     SELECT cm.id as cmid, q.id as quizid, c.id as courseid
                         FROM {course_modules} cm
-                        JOIN {quiz} q ON q.course = cm.course AND q.id = cm.instance
                         JOIN {course} c ON c.id = cm.course
                         JOIN {modules} m ON m.id = cm.module
+                        LEFT JOIN {quiz} q ON q.course = cm.course AND q.id = cm.instance AND m.name = 'quiz'
+                        LEFT JOIN {qbank} b ON b.course = cm.course AND b.id = cm.instance AND m.name = 'qbank' 
                         WHERE c.fullname = :coursename
-                                AND q.name = :quizname
-                                AND m.name = 'quiz'",
-                    ['coursename' => $coursename, 'quizname' => $modulename], $strictness = MUST_EXIST);
+                                AND (q.name = :modulename1 OR b.name = :modulename2)",
+                    ['coursename' => $coursename, 'modulename1' => $modulename, 'modulename2' => $modulename]);
                     $instanceid = $instancedata->cmid;
                     $result->coursename = $coursename;
                     $result->courseid = $instancedata->courseid;
@@ -118,13 +118,16 @@ function get_context(int $contextlevel, ?string $categoryname = null,
                     $result->quizid = $instancedata->quizid;
             } else {
                 $instancedata = $DB->get_record_sql("
-                SELECT c.fullname as coursename, q.name as modulename, q.id as quizid
+                SELECT c.fullname as coursename, CASE WHEN q.name IS NOT NULL THEN q.name
+                                                WHEN b.name IS NOT NULL THEN b.name
+                                                ELSE NULL END as modulename,
+                                                q.id as quizid
                     FROM {course_modules} cm
-                    JOIN {quiz} q ON q.course = cm.course AND q.id = cm.instance
                     JOIN {course} c ON c.id = cm.course
                     JOIN {modules} m ON m.id = cm.module
-                    WHERE cm.id = :instanceid
-                            AND m.name = 'quiz'",
+                    LEFT JOIN {quiz} q ON q.course = cm.course AND q.id = cm.instance AND m.name = 'quiz' 
+                    LEFT JOIN {qbank} b ON b.course = cm.course AND b.id = cm.instance AND m.name = 'qbank'
+                    WHERE cm.id = :instanceid",
                 ['instanceid' => $instanceid], $strictness = MUST_EXIST);
                 $result->coursename = $instancedata->coursename;
                 $result->modulename = $instancedata->modulename;

--- a/lib.php
+++ b/lib.php
@@ -100,7 +100,7 @@ function get_context(int $contextlevel, ?string $categoryname = null,
             return $result;
         case \CONTEXT_MODULE:
             $currentversion = normalize_version(get_config('', 'release'));
-            $isMoodle5plus =  (version_compare($currentversion, '5.0', '<')) ? false : true:
+            $isMoodle5plus =  (version_compare($currentversion, '5.0', '<')) ? false : true;
             if (is_null($instanceid)) {
                 // Assuming here that the module is a quiz or question bank.
                 if ($isMoodle5plus) {

--- a/lib.php
+++ b/lib.php
@@ -100,10 +100,10 @@ function get_context(int $contextlevel, ?string $categoryname = null,
             return $result;
         case \CONTEXT_MODULE:
             $currentversion = normalize_version(get_config('', 'release'));
-            $isMoodle5plus =  (version_compare($currentversion, '5.0', '<')) ? false : true;
+            $ismoodle5plus = (version_compare($currentversion, '5.0', '<')) ? false : true;
             if (is_null($instanceid)) {
                 // Assuming here that the module is a quiz or question bank.
-                if ($isMoodle5plus) {
+                if ($ismoodle5plus) {
                      // Assuming here that the module is a quiz or question bank.
                      $instancedata = $DB->get_record_sql("
                      SELECT cm.id as cmid, q.id as quizid, c.id as courseid
@@ -111,7 +111,7 @@ function get_context(int $contextlevel, ?string $categoryname = null,
                          JOIN {course} c ON c.id = cm.course
                          JOIN {modules} m ON m.id = cm.module
                          LEFT JOIN {quiz} q ON q.course = cm.course AND q.id = cm.instance AND m.name = 'quiz'
-                         LEFT JOIN {qbank} b ON b.course = cm.course AND b.id = cm.instance AND m.name = 'qbank' 
+                         LEFT JOIN {qbank} b ON b.course = cm.course AND b.id = cm.instance AND m.name = 'qbank'
                          WHERE c.fullname = :coursename
                                  AND (q.name = :modulename1 OR b.name = :modulename2)",
                      ['coursename' => $coursename, 'modulename1' => $modulename, 'modulename2' => $modulename]);
@@ -134,7 +134,7 @@ function get_context(int $contextlevel, ?string $categoryname = null,
                 $result->modulename = $modulename;
                 $result->quizid = $instancedata->quizid;
             } else {
-                if ($isMoodle5plus) {
+                if ($ismoodle5plus) {
                     $instancedata = $DB->get_record_sql("
                     SELECT c.fullname as coursename, CASE WHEN q.name IS NOT NULL THEN q.name
                                                     WHEN b.name IS NOT NULL THEN b.name
@@ -143,7 +143,7 @@ function get_context(int $contextlevel, ?string $categoryname = null,
                         FROM {course_modules} cm
                         JOIN {course} c ON c.id = cm.course
                         JOIN {modules} m ON m.id = cm.module
-                        LEFT JOIN {quiz} q ON q.course = cm.course AND q.id = cm.instance AND m.name = 'quiz' 
+                        LEFT JOIN {quiz} q ON q.course = cm.course AND q.id = cm.instance AND m.name = 'quiz'
                         LEFT JOIN {qbank} b ON b.course = cm.course AND b.id = cm.instance AND m.name = 'qbank'
                         WHERE cm.id = :instanceid",
                     ['instanceid' => $instanceid], $strictness = MUST_EXIST);

--- a/tests/external/get_question_list_test.php
+++ b/tests/external/get_question_list_test.php
@@ -30,7 +30,7 @@ global $CFG;
 require_once($CFG->dirroot . '/question/engine/tests/helpers.php');
 require_once($CFG->dirroot . '/webservice/tests/helpers.php');
 
-use \context_module;
+use context_module;
 use externallib_advanced_testcase;
 use external_api;
 use required_capability_exception;

--- a/tests/external/get_question_list_test.php
+++ b/tests/external/get_question_list_test.php
@@ -44,7 +44,7 @@ use moodle_exception;
  *
  * @covers \gitsync\external\get_question_list::execute
  */
-class get_question_list_test extends externallib_advanced_testcase {
+final class get_question_list_test extends externallib_advanced_testcase {
     /** @var \core_question_generator plugin generator */
     protected \core_question_generator $generator;
     /** @var \stdClass generated course object */
@@ -67,6 +67,7 @@ class get_question_list_test extends externallib_advanced_testcase {
     const QNAME = 'Example short answer question';
 
     public function setUp(): void {
+        parent::setUp();
         global $DB;
         $this->resetAfterTest();
         $this->generator = $this->getDataGenerator()->get_plugin_generator('core_question');
@@ -362,7 +363,7 @@ class get_question_list_test extends externallib_advanced_testcase {
      *
      * @return void
      */
-    public function test_get_category_path() {
+    public function test_get_category_path(): void {
         $qcategory2 = $this->generator->create_question_category(
             ['contextid' => $this->context->id, 'parent' => $this->qcategory->id, 'name' => "Tim's questions"]);
         $qcategory3 = $this->generator->create_question_category(

--- a/tests/external/get_question_list_test.php
+++ b/tests/external/get_question_list_test.php
@@ -30,7 +30,7 @@ global $CFG;
 require_once($CFG->dirroot . '/question/engine/tests/helpers.php');
 require_once($CFG->dirroot . '/webservice/tests/helpers.php');
 
-use context_course;
+use \context_module;
 use externallib_advanced_testcase;
 use external_api;
 use required_capability_exception;
@@ -44,11 +44,17 @@ use moodle_exception;
  *
  * @covers \gitsync\external\get_question_list::execute
  */
-final class get_question_list_test extends externallib_advanced_testcase {
+class get_question_list_test extends externallib_advanced_testcase {
     /** @var \core_question_generator plugin generator */
-    protected \core_question_generator  $generator;
+    protected \core_question_generator $generator;
     /** @var \stdClass generated course object */
     protected \stdClass $course;
+    /** @var \stdClass generated module object */
+    protected \stdClass $module;
+    /** @var \stdClass context of course */
+    protected \stdClass $coursecontext;
+    /** @var \stdClass context of module */
+    protected \stdClass $context;
     /** @var \stdClass generated question_category object */
     protected \stdClass $qcategory;
     /** @var \stdClass generated question object */
@@ -61,13 +67,26 @@ final class get_question_list_test extends externallib_advanced_testcase {
     const QNAME = 'Example short answer question';
 
     public function setUp(): void {
-        parent::setUp();
         global $DB;
         $this->resetAfterTest();
         $this->generator = $this->getDataGenerator()->get_plugin_generator('core_question');
         $this->course = $this->getDataGenerator()->create_course();
+        $this->coursecontext = \context_course::instance($this->course->id);
+        $this->module = $this->getDataGenerator()->create_module('quiz', ['course' => $this->course->id, 'name' => 'QUIZ TEST']);
+        $this->context = \context_module::instance($this->module->cmid);
+        if (function_exists('question_get_default_category')) {
+            // This function exists from Moodle 4.5 onwards but the second parameter
+            // which creates the category if it doesn't exist is 5.0 onwards.
+            $category = question_get_default_category($this->context->id, true);
+            if (!$category) {
+                $category = question_make_default_categories([$this->context]);
+            }
+        } else {
+            // Deprecated from 5.0.
+            $category = question_make_default_categories([$this->context]);
+        }
         $this->qcategory = $this->generator->create_question_category(
-                        ['contextid' => \context_course::instance($this->course->id)->id]);
+                        ['contextid' => $this->context->id]);
         $user = $this->getDataGenerator()->create_user();
         $this->user = $user;
         $this->setUser($user);
@@ -84,12 +103,11 @@ final class get_question_list_test extends externallib_advanced_testcase {
     public function test_capabilities(): void {
         global $DB;
         // Set the required capabilities - webservice access and list rights on course.
-        $context = context_course::instance($this->course->id);
         $managerroleid = $DB->get_field('role', 'id', ['shortname' => 'manager']);
-        role_assign($managerroleid, $this->user->id, $context->id);
+        role_assign($managerroleid, $this->user->id, $this->coursecontext->id);
 
-        $returnvalue = get_question_list::execute('top', 50, get_config('qbank_gitsync')->version,
-                                                  $this->course->fullname, null, null,
+        $returnvalue = get_question_list::execute('top', 70, get_config('qbank_gitsync')->version,
+                                                  $this->course->fullname, $this->module->name, null,
                                                   null, null, false, ['']);
 
         // We need to execute the return values cleaning process to simulate
@@ -108,29 +126,12 @@ final class get_question_list_test extends externallib_advanced_testcase {
      * Test the execute function fails when not logged in.
      */
     public function test_not_logged_in(): void {
-        global $DB;
         $this->setUser();
         $this->expectException(require_login_exception::class);
         // Exception messages don't seem to get translated.
         $this->expectExceptionMessage('not logged in');
-        get_question_list::execute('top', 50, get_config('qbank_gitsync')->version, $this->course->fullname, null, null,
-                                   null, null, false, ['']);
-    }
-
-    /**
-     * Test if mismatched versions.
-     */
-    public function test_mismatched_versions(): void {
-        global $DB;
-        // Set the required capabilities - webservice access and list rights on course.
-        $context = context_course::instance($this->course->id);
-        $managerroleid = $DB->get_field('role', 'id', ['shortname' => 'manager']);
-        role_assign($managerroleid, $this->user->id, $context->id);
-        $this->expectException(moodle_exception::class);
-        // Exception messages don't seem to get translated.
-        $this->expectExceptionMessage('Your local version of Gitsync (12345) does not match');
-        get_question_list::execute('top', 50, '12345', $this->course->fullname, null, null,
-                                   null, null, false, ['']);
+        get_question_list::execute('top', 70, get_config('qbank_gitsync')->version, $this->course->fullname,
+                                   $this->module->name, null, null, null, false, ['']);
     }
 
     /**
@@ -138,14 +139,13 @@ final class get_question_list_test extends externallib_advanced_testcase {
      */
     public function test_no_webservice_access(): void {
         global $DB;
-        $context = context_course::instance($this->course->id);
         $managerroleid = $DB->get_field('role', 'id', ['shortname' => 'manager']);
-        role_assign($managerroleid, $this->user->id, $context->id);
+        role_assign($managerroleid, $this->user->id, $this->coursecontext->id);
         $this->unassignUserCapability('qbank/gitsync:listquestions', \context_system::instance()->id, $managerroleid);
         $this->expectException(required_capability_exception::class);
         $this->expectExceptionMessage('you do not currently have permissions to do that (List)');
-        get_question_list::execute('top', 50, get_config('qbank_gitsync')->version, $this->course->fullname, null, null,
-                                   null, null, false, ['']);
+        get_question_list::execute('top', 70, get_config('qbank_gitsync')->version, $this->course->fullname,
+                                   $this->module->name, null, null, null, false, ['']);
     }
 
     /**
@@ -154,8 +154,8 @@ final class get_question_list_test extends externallib_advanced_testcase {
     public function test_list_capability(): void {
         $this->expectException(require_login_exception::class);
         $this->expectExceptionMessage('Not enrolled');
-        get_question_list::execute('top', 50, get_config('qbank_gitsync')->version, $this->course->fullname, null, null,
-                                   null, null, false, ['']);
+        get_question_list::execute('top', 70, get_config('qbank_gitsync')->version, $this->course->fullname,
+                                   $this->module->name, null, null, null, false, ['']);
     }
 
     /**
@@ -163,22 +163,22 @@ final class get_question_list_test extends externallib_advanced_testcase {
      */
     public function test_question_is_in_supplied_context(): void {
         global $DB;
-        $context = context_course::instance($this->course->id);
-        $course2 = $this->getDataGenerator()->create_course();
-        $catincourse2 = $this->generator->create_question_category(['contextid' => \context_course::instance($course2->id)->id]);
-        $qincourse2 = $this->generator->create_question('numerical', null,
-            ['name' => 'Example numerical question', 'category' => $catincourse2->id]);
-        $qbankentryid2 = $DB->get_field('question_versions', 'questionbankentryid',
-                                        ['questionid' => $qincourse2->id], $strictness = MUST_EXIST);
+        $course2 = $this->getDataGenerator()->create_course(['name' => 'Course2']);
+        $quiz2 = $this->getDataGenerator()->create_module('quiz', ['course' => $course2->id, 'name' => 'QUIZ2 TEST']);
+        $quiz2context = \context_module::instance($quiz2->cmid);
+        $catinquiz2 = $this->generator->create_question_category(['contextid' => $quiz2context->id]);
+
+        $qinquiz2 = $this->generator->create_question('numerical', null,
+            ['name' => 'Example numerical question', 'category' => $catinquiz2->id]);
 
         $managerroleid = $DB->get_field('role', 'id', ['shortname' => 'manager']);
-        role_assign($managerroleid, $this->user->id, $context->id);
+        role_assign($managerroleid, $this->user->id, $this->coursecontext->id);
         $this->expectException(moodle_exception::class);
         $this->expectExceptionMessage('Not enrolled');
         // Trying to list question from course 2 using context of course 1.
         // User has list capability on course 1 but not course 2.
-        get_question_list::execute('top', 50, get_config('qbank_gitsync')->version, $course2->fullname, null, null,
-                                   null, null, false, ['']);
+        get_question_list::execute('top', 70, get_config('qbank_gitsync')->version, $course2->fullname,
+                                   $quiz2->name, null, null, null, false, ['']);
     }
 
     /**
@@ -187,34 +187,18 @@ final class get_question_list_test extends externallib_advanced_testcase {
     public function test_list(): void {
         global $DB;
         // Set the required capabilities - webservice access and list rights on course.
-        $context = context_course::instance($this->course->id);
         $managerroleid = $DB->get_field('role', 'id', ['shortname' => 'manager']);
-        role_assign($managerroleid, $this->user->id, $context->id);
+        role_assign($managerroleid, $this->user->id, $this->coursecontext->id);
+
         $qcategory2 = $this->generator->create_question_category(
-            ['contextid' => \context_course::instance($this->course->id)->id]);
+            ['contextid' => $this->context->id]);
         $q2 = $this->generator->create_question('shortanswer', null,
                                                 ['name' => self::QNAME . '2', 'category' => $qcategory2->id]);
         $qbankentryid2 = $DB->get_field('question_versions', 'questionbankentryid',
                              ['questionid' => $q2->id], $strictness = MUST_EXIST);
-        $quizgenerator = new \testing_data_generator();
-        $quizgenerator = $quizgenerator->get_plugin_generator('mod_quiz');
-
-        $quiz = $quizgenerator->create_instance(['course' => $this->course->id,
-            'name' => 'Quiz 1', 'questionsperpage' => 0,
-            'grade' => 100.0, 'sumgrades' => 2, 'preferredbehaviour' => 'immediatefeedback']);
-
-        \quiz_add_quiz_question($this->q->id, $quiz);
-        \quiz_add_quiz_question($q2->id, $quiz);
-        if (class_exists('\mod_quiz\quiz_settings')) {
-            $quizobj = \mod_quiz\quiz_settings::create($quiz->id);
-        } else {
-            $quizobj = \quiz::create($quiz->id);
-        }
-        \mod_quiz\structure::create_for_quiz($quizobj);
         $sink = $this->redirectEvents();
-        $returnvalue = get_question_list::execute('top', 50, get_config('qbank_gitsync')->version,
-                                                  $this->course->fullname, null, null,
-                                                  null, null, false, ['']);
+        $returnvalue = get_question_list::execute('top', 70, get_config('qbank_gitsync')->version, $this->course->fullname,
+                                                  $this->module->name, null, null, null, false, [''], '');
 
         $returnvalue = external_api::clean_returnvalue(
             get_question_list::execute_returns(),
@@ -238,12 +222,9 @@ final class get_question_list_test extends externallib_advanced_testcase {
         $this->assertEquals($qcategory2->name, $returnedq2['questioncategory']);
 
         $this->assertEquals($this->course->fullname, $returnvalue['contextinfo']['coursename']);
-        $this->assertEquals($this->course->id, $returnvalue['contextinfo']['instanceid']);
+        $this->assertEquals($this->module->cmid, $returnvalue['contextinfo']['instanceid']);
         $this->assertEquals(null, $returnvalue['contextinfo']['categoryname']);
-        $this->assertEquals(null, $returnvalue['contextinfo']['modulename']);
-        $this->assertEquals(1, count($returnvalue['quizzes']));
-        $this->assertEquals('Quiz 1', $returnvalue['quizzes'][0]['name']);
-        $this->assertEquals($quiz->cmid, $returnvalue['quizzes'][0]['instanceid']);
+        $this->assertEquals($this->module->name, $returnvalue['contextinfo']['modulename']);
 
         $events = $sink->get_events();
         $this->assertEquals(count($events), 0);
@@ -255,18 +236,16 @@ final class get_question_list_test extends externallib_advanced_testcase {
     public function test_list_instanceid(): void {
         global $DB;
         // Set the required capabilities - webservice access and list rights on course.
-        $context = context_course::instance($this->course->id);
         $managerroleid = $DB->get_field('role', 'id', ['shortname' => 'manager']);
-        role_assign($managerroleid, $this->user->id, $context->id);
-        $qcategory2 = $this->generator->create_question_category(
-            ['contextid' => \context_course::instance($this->course->id)->id]);
+        role_assign($managerroleid, $this->user->id, $this->coursecontext->id);
+        $qcategory2 = $this->generator->create_question_category(['contextid' => $this->context->id]);
         $q2 = $this->generator->create_question('shortanswer', null,
                                                 ['name' => self::QNAME . '2', 'category' => $qcategory2->id]);
         $qbankentryid2 = $DB->get_field('question_versions', 'questionbankentryid',
                              ['questionid' => $q2->id], $strictness = MUST_EXIST);
         $sink = $this->redirectEvents();
-        $returnvalue = get_question_list::execute('top', 50, get_config('qbank_gitsync')->version, null, null, null,
-                                                  null, $this->course->id, false, ['']);
+        $returnvalue = get_question_list::execute('top', 70, get_config('qbank_gitsync')->version, null, null,
+                                                  null, null, $this->module->cmid, false, ['']);
 
         $returnvalue = external_api::clean_returnvalue(
             get_question_list::execute_returns(),
@@ -290,9 +269,9 @@ final class get_question_list_test extends externallib_advanced_testcase {
         $this->assertEquals($qcategory2->name, $returnedq2['questioncategory']);
 
         $this->assertEquals($this->course->fullname, $returnvalue['contextinfo']['coursename']);
-        $this->assertEquals($this->course->id, $returnvalue['contextinfo']['instanceid']);
+        $this->assertEquals($this->module->cmid, $returnvalue['contextinfo']['instanceid']);
         $this->assertEquals(null, $returnvalue['contextinfo']['categoryname']);
-        $this->assertEquals(null, $returnvalue['contextinfo']['modulename']);
+        $this->assertEquals($this->module->name, $returnvalue['contextinfo']['modulename']);
 
         $events = $sink->get_events();
         $this->assertEquals(count($events), 0);
@@ -304,25 +283,24 @@ final class get_question_list_test extends externallib_advanced_testcase {
     public function test_list_with_array(): void {
         global $DB;
         // Set the required capabilities - webservice access and list rights on course.
-        $context = context_course::instance($this->course->id);
         $managerroleid = $DB->get_field('role', 'id', ['shortname' => 'manager']);
-        role_assign($managerroleid, $this->user->id, $context->id);
-        $qcategory2 = $this->generator->create_question_category(
-            ['contextid' => \context_course::instance($this->course->id)->id]);
+        role_assign($managerroleid, $this->user->id, $this->coursecontext->id);
+        $qcategory2 = $this->generator->create_question_category(['contextid' => $this->context->id]);
         $q2 = $this->generator->create_question('shortanswer', null,
                                                 ['name' => self::QNAME . '2', 'category' => $qcategory2->id]);
         $qbankentryid2 = $DB->get_field('question_versions', 'questionbankentryid',
                              ['questionid' => $q2->id], $strictness = MUST_EXIST);
-        $course2 = $this->getDataGenerator()->create_course();
-        $catincourse2 = $this->generator->create_question_category(['contextid' => \context_course::instance($course2->id)->id]);
-        $qincourse2 = $this->generator->create_question('numerical', null,
-            ['name' => 'Example numerical question', 'category' => $catincourse2->id]);
+        $quiz2 = $this->getDataGenerator()->create_module('quiz', ['course' => $this->course->id, 'name' => 'QUIZ2 TEST']);
+        $quiz2context = \context_module::instance($quiz2->cmid);
+        $catinquiz2 = $this->generator->create_question_category(['contextid' => $quiz2context->id]);
+        $qinquiz2 = $this->generator->create_question('numerical', null,
+                                            ['name' => 'Example numerical question', 'category' => $catinquiz2->id]);
         $qbankentryid3 = $DB->get_field('question_versions', 'questionbankentryid',
-                                                             ['questionid' => $qincourse2->id], $strictness = MUST_EXIST);
+                                                             ['questionid' => $qinquiz2->id], $strictness = MUST_EXIST);
 
         $sink = $this->redirectEvents();
-        $returnvalue = get_question_list::execute('top', 50, get_config('qbank_gitsync')->version, null, null, null,
-                                                  null, $this->course->id, false, [$qbankentryid2, $qbankentryid3]);
+        $returnvalue = get_question_list::execute('top', 70, get_config('qbank_gitsync')->version, null, null,
+                                                    null, null, $this->module->cmid, false, [$qbankentryid2, $qbankentryid3], '');
 
         $returnvalue = external_api::clean_returnvalue(
             get_question_list::execute_returns(),
@@ -351,9 +329,9 @@ final class get_question_list_test extends externallib_advanced_testcase {
         $this->assertEquals(null, $returnedq3['questioncategory']);
 
         $this->assertEquals($this->course->fullname, $returnvalue['contextinfo']['coursename']);
-        $this->assertEquals($this->course->id, $returnvalue['contextinfo']['instanceid']);
+        $this->assertEquals($this->module->cmid, $returnvalue['contextinfo']['instanceid']);
         $this->assertEquals(null, $returnvalue['contextinfo']['categoryname']);
-        $this->assertEquals(null, $returnvalue['contextinfo']['modulename']);
+        $this->assertEquals($this->module->name, $returnvalue['contextinfo']['modulename']);
 
         $events = $sink->get_events();
         $this->assertEquals(count($events), 0);
@@ -364,17 +342,18 @@ final class get_question_list_test extends externallib_advanced_testcase {
      */
     public function test_question_category_is_in_supplied_context(): void {
         global $DB;
-        $course2 = $this->getDataGenerator()->create_course();
-        $catincourse2 = $this->generator->create_question_category(['contextid' => \context_course::instance($course2->id)->id]);
-        $context = context_course::instance($this->course->id);
+        $course2 = $this->getDataGenerator()->create_course(['name' => 'Course2']);
+        $quiz2 = $this->getDataGenerator()->create_module('quiz', ['course' => $course2->id, 'name' => 'QUIZ2 TEST']);
+        $quiz2context = \context_module::instance($quiz2->cmid);
+        $catinquiz2 = $this->generator->create_question_category(['contextid' => $quiz2context->id]);
         $managerroleid = $DB->get_field('role', 'id', ['shortname' => 'manager']);
-        role_assign($managerroleid, $this->user->id, $context->id);
+        role_assign($managerroleid, $this->user->id, $this->coursecontext->id);
         $this->expectException(moodle_exception::class);
         $this->expectExceptionMessage('The category is not in the supplied context.');
         // Trying to list question from course 2 using context of course 1.
         // User has list capability on course 1 but not course 2.
-        get_question_list::execute('top', 50, get_config('qbank_gitsync')->version, $this->course->fullname, null, null,
-                                    $catincourse2->id, null, false, ['']);
+        get_question_list::execute('top', 70, get_config('qbank_gitsync')->version, $this->course->fullname,
+                                                  $this->module->name, null, $catinquiz2->id, null, false, [''], '');
     }
 
     /**
@@ -383,18 +362,17 @@ final class get_question_list_test extends externallib_advanced_testcase {
      *
      * @return void
      */
-    public function test_get_category_path(): void {
-        $contextid = \context_course::instance($this->course->id)->id;
+    public function test_get_category_path() {
         $qcategory2 = $this->generator->create_question_category(
-            ['contextid' => $contextid, 'parent' => $this->qcategory->id, 'name' => "Tim's questions"]);
+            ['contextid' => $this->context->id, 'parent' => $this->qcategory->id, 'name' => "Tim's questions"]);
         $qcategory3 = $this->generator->create_question_category(
-            ['contextid' => $contextid, 'parent' => $qcategory2->id, 'name' => "Tricky things like / // and so on"]);
+            ['contextid' => $this->context->id, 'parent' => $qcategory2->id, 'name' => "Tricky things like / // and so on"]);
         $qcategory4 = $this->generator->create_question_category(
-            ['contextid' => $contextid, 'parent' => $qcategory3->id, 'name' => 'Category name ending in /']);
+            ['contextid' => $this->context->id, 'parent' => $qcategory3->id, 'name' => 'Category name ending in /']);
         $qcategory5 = $this->generator->create_question_category(
-            ['contextid' => $contextid, 'parent' => $qcategory4->id, 'name' => '/ and one that starts with one']);
+            ['contextid' => $this->context->id, 'parent' => $qcategory4->id, 'name' => '/ and one that starts with one']);
         $qcategory6 = $this->generator->create_question_category(
-            ['contextid' => $contextid, 'parent' => $qcategory5->id,
+            ['contextid' => $this->context->id, 'parent' => $qcategory5->id,
              'name' => '<span lang="en" class="multilang">Matematically</span> ' .
              '<span lang="sv" class="multilang">Matematiskt (svenska)</span>"',
             ]);
@@ -412,19 +390,17 @@ final class get_question_list_test extends externallib_advanced_testcase {
     public function test_list_with_subcategory_name(): void {
         global $DB;
         // Set the required capabilities - webservice access and list rights on course.
-        $context = context_course::instance($this->course->id);
         $managerroleid = $DB->get_field('role', 'id', ['shortname' => 'manager']);
-        role_assign($managerroleid, $this->user->id, $context->id);
+        role_assign($managerroleid, $this->user->id, $this->coursecontext->id);
         $qcategory2 = $this->generator->create_question_category(
-            ['contextid' => \context_course::instance($this->course->id)->id]);
+            ['contextid' => $this->context->id]);
         $q2 = $this->generator->create_question('shortanswer', null,
                                                 ['name' => self::QNAME . '2', 'category' => $qcategory2->id]);
         $qbankentryid2 = $DB->get_field('question_versions', 'questionbankentryid',
                              ['questionid' => $q2->id], $strictness = MUST_EXIST);
         $sink = $this->redirectEvents();
-        $returnvalue = get_question_list::execute('top/' . $qcategory2->name, 50, get_config('qbank_gitsync')->version,
-                                                  $this->course->fullname, null, null,
-                                                  null, null, false, ['']);
+        $returnvalue = get_question_list::execute('top/' . $qcategory2->name, 70, get_config('qbank_gitsync')->version,
+                                                  $this->course->fullname, $this->module->name, null, null, null, false, [''], '');
 
         $returnvalue = external_api::clean_returnvalue(
             get_question_list::execute_returns(),
@@ -443,9 +419,9 @@ final class get_question_list_test extends externallib_advanced_testcase {
         $this->assertEquals($qcategory2->name, $returnedq2['questioncategory']);
 
         $this->assertEquals($this->course->fullname, $returnvalue['contextinfo']['coursename']);
-        $this->assertEquals($this->course->id, $returnvalue['contextinfo']['instanceid']);
+        $this->assertEquals($this->module->cmid, $returnvalue['contextinfo']['instanceid']);
         $this->assertEquals(null, $returnvalue['contextinfo']['categoryname']);
-        $this->assertEquals(null, $returnvalue['contextinfo']['modulename']);
+        $this->assertEquals($this->module->name, $returnvalue['contextinfo']['modulename']);
 
         $events = $sink->get_events();
         $this->assertEquals(count($events), 0);
@@ -457,19 +433,18 @@ final class get_question_list_test extends externallib_advanced_testcase {
     public function test_list_with_subcategory_id(): void {
         global $DB;
         // Set the required capabilities - webservice access and list rights on course.
-        $context = context_course::instance($this->course->id);
         $managerroleid = $DB->get_field('role', 'id', ['shortname' => 'manager']);
-        role_assign($managerroleid, $this->user->id, $context->id);
+        role_assign($managerroleid, $this->user->id, $this->coursecontext->id);
         $qcategory2 = $this->generator->create_question_category(
-            ['contextid' => \context_course::instance($this->course->id)->id]);
+            ['contextid' => $this->context->id]);
         $q2 = $this->generator->create_question('shortanswer', null,
                                                 ['name' => self::QNAME . '2', 'category' => $qcategory2->id]);
         $qbankentryid2 = $DB->get_field('question_versions', 'questionbankentryid',
                              ['questionid' => $q2->id], $strictness = MUST_EXIST);
         $sink = $this->redirectEvents();
-        $returnvalue = get_question_list::execute('top', 50, get_config('qbank_gitsync')->version,
-                                $this->course->fullname, null, null,
-                                $qcategory2->id, null, false, ['']);
+        $returnvalue = get_question_list::execute('top', 70, get_config('qbank_gitsync')->version,
+                                                  $this->course->fullname, $this->module->name,
+                                                  null, $qcategory2->id, null, false, [''], '');
 
         $returnvalue = external_api::clean_returnvalue(
             get_question_list::execute_returns(),
@@ -488,9 +463,9 @@ final class get_question_list_test extends externallib_advanced_testcase {
         $this->assertEquals($qcategory2->name, $returnedq2['questioncategory']);
 
         $this->assertEquals($this->course->fullname, $returnvalue['contextinfo']['coursename']);
-        $this->assertEquals($this->course->id, $returnvalue['contextinfo']['instanceid']);
+        $this->assertEquals($this->module->cmid, $returnvalue['contextinfo']['instanceid']);
         $this->assertEquals(null, $returnvalue['contextinfo']['categoryname']);
-        $this->assertEquals(null, $returnvalue['contextinfo']['modulename']);
+        $this->assertEquals($this->module->name, $returnvalue['contextinfo']['modulename']);
 
         $events = $sink->get_events();
         $this->assertEquals(count($events), 0);
@@ -503,16 +478,15 @@ final class get_question_list_test extends externallib_advanced_testcase {
         global $DB;
         // Set the required capabilities - webservice access and list rights on course.
         // Q1 in original category. Q2 in Cat2. Q3 in SubCat1. Q4 in SubCat2.
-        $context = context_course::instance($this->course->id);
         $managerroleid = $DB->get_field('role', 'id', ['shortname' => 'manager']);
-        role_assign($managerroleid, $this->user->id, $context->id);
+        role_assign($managerroleid, $this->user->id, $this->coursecontext->id);
         $qcategory2 = $this->generator->create_question_category(
-            ['contextid' => \context_course::instance($this->course->id)->id, 'name' => 'Cat2_DO_NOT_SHARE']);
+            ['contextid' => $this->context->id, 'name' => 'Cat2_DO_NOT_SHARE']);
         $qcategory3 = $this->generator->create_question_category(
-            ['contextid' => \context_course::instance($this->course->id)->id, 'name' => 'SubCat1',
+            ['contextid' => $this->context->id, 'name' => 'SubCat1',
             'parent' => $qcategory2->id]);
         $qcategory4 = $this->generator->create_question_category(
-            ['contextid' => \context_course::instance($this->course->id)->id, 'name' => 'SubCat2',
+            ['contextid' => $this->context->id, 'name' => 'SubCat2',
             'parent' => $qcategory2->id]);
 
         $q2 = $this->generator->create_question('shortanswer', null,
@@ -523,9 +497,9 @@ final class get_question_list_test extends externallib_advanced_testcase {
                                             ['name' => self::QNAME . '4', 'category' => $qcategory4->id]);
 
         $sink = $this->redirectEvents();
-        $returnvalue = get_question_list::execute('top', 50, get_config('qbank_gitsync')->version,
-                                                  $this->course->fullname, null, null,
-                                                  null, null, false, [''], '/.*DO_NOT_SHARE/');
+        $returnvalue = get_question_list::execute('top', 70, get_config('qbank_gitsync')->version,
+                                                  $this->course->fullname, $this->module->name,
+                                                  null, null, null, false, [''], '/.*DO_NOT_SHARE/');
 
         $returnvalue = external_api::clean_returnvalue(
             get_question_list::execute_returns(),
@@ -543,9 +517,9 @@ final class get_question_list_test extends externallib_advanced_testcase {
         $this->assertEquals($wrongq, false);
 
         $this->assertEquals($this->course->fullname, $returnvalue['contextinfo']['coursename']);
-        $this->assertEquals($this->course->id, $returnvalue['contextinfo']['instanceid']);
+        $this->assertEquals($this->module->cmid, $returnvalue['contextinfo']['instanceid']);
         $this->assertEquals(null, $returnvalue['contextinfo']['categoryname']);
-        $this->assertEquals(null, $returnvalue['contextinfo']['modulename']);
+        $this->assertEquals($this->module->name, $returnvalue['contextinfo']['modulename']);
         $this->assertEquals('/.*DO_NOT_SHARE/', $returnvalue['contextinfo']['ignorecat']);
 
         $events = $sink->get_events();
@@ -559,16 +533,15 @@ final class get_question_list_test extends externallib_advanced_testcase {
         global $DB;
         // Set the required capabilities - webservice access and list rights on course.
         // Q1 in original category. Q2 in Cat2. Q3 in SubCat1. Q4 in SubCat2.
-        $context = context_course::instance($this->course->id);
         $managerroleid = $DB->get_field('role', 'id', ['shortname' => 'manager']);
-        role_assign($managerroleid, $this->user->id, $context->id);
+        role_assign($managerroleid, $this->user->id, $this->coursecontext->id);
         $qcategory2 = $this->generator->create_question_category(
-            ['contextid' => \context_course::instance($this->course->id)->id, 'name' => 'Cat2']);
+            ['contextid' => $this->context->id, 'name' => 'Cat2']);
         $qcategory3 = $this->generator->create_question_category(
-            ['contextid' => \context_course::instance($this->course->id)->id, 'name' => 'SubCat1',
+            ['contextid' => $this->context->id, 'name' => 'SubCat1',
             'parent' => $qcategory2->id]);
         $qcategory4 = $this->generator->create_question_category(
-            ['contextid' => \context_course::instance($this->course->id)->id, 'name' => 'SubCat2_DO_NOT_SHARE',
+            ['contextid' => $this->context->id, 'name' => 'SubCat2_DO_NOT_SHARE',
             'parent' => $qcategory2->id]);
 
         $q2 = $this->generator->create_question('shortanswer', null,
@@ -584,9 +557,10 @@ final class get_question_list_test extends externallib_advanced_testcase {
                              ['questionid' => $q3->id], $strictness = MUST_EXIST);
 
         $sink = $this->redirectEvents();
-        $returnvalue = get_question_list::execute('top/' . $qcategory2->name, 50, get_config('qbank_gitsync')->version,
-                                                  $this->course->fullname, null, null,
-                                                  null, null, false, [''], '/.*DO_NOT_SHARE/');
+
+        $returnvalue = get_question_list::execute('top/' . $qcategory2->name, 70, get_config('qbank_gitsync')->version,
+                                                  $this->course->fullname, $this->module->name,
+                                                  null, null, null, false, [''], '/.*DO_NOT_SHARE/');
 
         $returnvalue = external_api::clean_returnvalue(
             get_question_list::execute_returns(),
@@ -605,9 +579,9 @@ final class get_question_list_test extends externallib_advanced_testcase {
         $this->assertEquals($wrongq, false);
 
         $this->assertEquals($this->course->fullname, $returnvalue['contextinfo']['coursename']);
-        $this->assertEquals($this->course->id, $returnvalue['contextinfo']['instanceid']);
+        $this->assertEquals($this->module->cmid, $returnvalue['contextinfo']['instanceid']);
         $this->assertEquals(null, $returnvalue['contextinfo']['categoryname']);
-        $this->assertEquals(null, $returnvalue['contextinfo']['modulename']);
+        $this->assertEquals($this->module->name, $returnvalue['contextinfo']['modulename']);
         $this->assertEquals('/.*DO_NOT_SHARE/', $returnvalue['contextinfo']['ignorecat']);
 
         $events = $sink->get_events();

--- a/tests/external/import_question_test.php
+++ b/tests/external/import_question_test.php
@@ -51,6 +51,12 @@ final class import_question_test extends externallib_advanced_testcase {
     protected \core_question_generator $generator;
     /** @var generated course object */
     protected \stdClass $course;
+    /** @var \stdClass generated module object */
+    protected \stdClass $module;
+    /** @var \stdClass context of course */
+    protected \context_course $coursecontext;
+    /** @var \stdClass context of module */
+    protected \stdClass $context;
     /** @var \stdClass generated question_category object */
     protected \stdClass $qcategory;
     /** @var array information about uploaded file */
@@ -68,6 +74,20 @@ final class import_question_test extends externallib_advanced_testcase {
         $this->resetAfterTest();
         $this->generator = $this->getDataGenerator()->get_plugin_generator('core_question');
         $this->course = $this->getDataGenerator()->create_course();
+        $this->coursecontext = \context_course::instance($this->course->id);
+        $this->module = $this->getDataGenerator()->create_module('quiz', ['course' => $this->course->id, 'name' => 'QUIZ TEST']);
+        $this->context = \context_module::instance($this->module->cmid);
+        if (function_exists('question_get_default_category')) {
+            // This function exists from Moodle 4.5 onwards but the second parameter
+            // which creates the category if it doesn't exist is 5.0 onwards.
+            $category = question_get_default_category($this->context->id, true);
+            if (!$category) {
+                $category = question_make_default_categories([$this->context]);
+            }
+        } else {
+            // Deprecated from 5.0.
+            $category = question_make_default_categories([$this->context]);
+        }
         $this->qcategory = $this->generator->create_question_category(
                                 ['contextid' => \context_course::instance($this->course->id)->id]);
         $user = $this->getDataGenerator()->create_user();
@@ -118,10 +138,9 @@ final class import_question_test extends externallib_advanced_testcase {
     public function give_capabilities(): context_course {
         global $DB;
         // Set the required capabilities - webservice access and export rights on course.
-        $context = context_course::instance($this->course->id);
         $managerroleid = $DB->get_field('role', 'id', ['shortname' => 'manager']);
-        role_assign($managerroleid, $this->user->id, $context->id);
-        return $context;
+        role_assign($managerroleid, $this->user->id, $this->coursecontext->id);
+        return $this->coursecontext;
     }
 
     /**
@@ -133,8 +152,8 @@ final class import_question_test extends externallib_advanced_testcase {
         $returnvalue = import_question::execute('', '', '',
                                                 null,
                                                 $this->fileinfo,
-                                                50,
-                                                $this->course->fullname);
+                                                70,
+                                                $this->course->fullname, $this->module->name);
 
         // We need to execute the return values cleaning process to simulate
         // the web service server.
@@ -157,7 +176,11 @@ final class import_question_test extends externallib_advanced_testcase {
         $this->expectException(require_login_exception::class);
         // Exception messages don't seem to get translated.
         $this->expectExceptionMessage('not logged in');
-        import_question::execute('', '', '', null, $this->fileinfo, 50, $this->course->fullname);
+        import_question::execute('', '', '',
+                                 null,
+                                 $this->fileinfo,
+                                 70,
+                                 $this->course->fullname, $this->module->name);
     }
 
     /**
@@ -165,13 +188,16 @@ final class import_question_test extends externallib_advanced_testcase {
      */
     public function test_no_webservice_access(): void {
         global $DB;
-        $context = context_course::instance($this->course->id);
         $managerroleid = $DB->get_field('role', 'id', ['shortname' => 'manager']);
-        role_assign($managerroleid, $this->user->id, $context->id);
+        role_assign($managerroleid, $this->user->id, $this->coursecontext->id);
         $this->unassignUserCapability('qbank/gitsync:importquestions', \context_system::instance()->id, $managerroleid);
         $this->expectException(required_capability_exception::class);
         $this->expectExceptionMessage('you do not currently have permissions to do that (Import)');
-        import_question::execute('', '', '', null, $this->fileinfo, 50, $this->course->fullname);
+        import_question::execute('', '', '',
+                                 null,
+                                 $this->fileinfo,
+                                 70,
+                                 $this->course->fullname, $this->module->name);
     }
 
     /**
@@ -180,7 +206,11 @@ final class import_question_test extends externallib_advanced_testcase {
     public function test_import_capability(): void {
         $this->expectException(require_login_exception::class);
         $this->expectExceptionMessage('Not enrolled');
-        import_question::execute('', '', '', null, $this->fileinfo, 50, $this->course->fullname);
+        import_question::execute('', '', '',
+                                 null,
+                                 $this->fileinfo,
+                                 70,
+                                 $this->course->fullname, $this->module->name);
     }
 
     /**
@@ -189,7 +219,7 @@ final class import_question_test extends externallib_advanced_testcase {
      */
     public function test_category_import(): void {
         global $DB;
-        $context = $this->give_capabilities();
+        $this->give_capabilities();
         $this->upload_file($this->testrepo . 'top/cat-1/gitsync_category.xml');
         $createdcategory = $DB->get_record('question_categories', ['name' => 'cat 1'], '*');
         $this->assertEquals($createdcategory, false);
@@ -199,12 +229,12 @@ final class import_question_test extends externallib_advanced_testcase {
         $returnvalue = import_question::execute('', '', '',
                                                 null,
                                                 $this->fileinfo,
-                                                50,
-                                                $this->course->fullname);
+                                                70,
+                                                $this->course->fullname, $this->module->name);
         $createdcategory = $DB->get_record('question_categories', ['name' => 'cat 1'], '*', $strictness = MUST_EXIST);
-        $this->assertEquals($createdcategory->contextid, $context->id);
+        $this->assertEquals($createdcategory->contextid, $this->context->id);
         $parentcategory = $DB->get_record('question_categories',
-                                          ['name' => 'top', 'contextid' => $context->id],
+                                          ['name' => 'top', 'contextid' => $this->context->id],
                                           '*',
                                           $strictness = MUST_EXIST);
         $this->assertEquals($createdcategory->parent, $parentcategory->id);
@@ -227,7 +257,7 @@ final class import_question_test extends externallib_advanced_testcase {
      */
     public function test_subcategory_import(): void {
         global $DB;
-        $context = $this->give_capabilities();
+        $this->give_capabilities();
         $this->upload_file($this->testrepo . 'top/cat-2/subcat-2_1/gitsync_category.xml');
         $createdcategory = $DB->get_record('question_categories', ['name' => 'cat 2'], '*');
         $this->assertEquals($createdcategory, false);
@@ -239,12 +269,12 @@ final class import_question_test extends externallib_advanced_testcase {
         $returnvalue = import_question::execute('', '', '',
                                                 null,
                                                 $this->fileinfo,
-                                                50,
-                                                $this->course->fullname);
+                                                70,
+                                                $this->course->fullname, $this->module->name);
         $createdcategory = $DB->get_record('question_categories', ['name' => 'cat 2'], '*', $strictness = MUST_EXIST);
-        $this->assertEquals($createdcategory->contextid, $context->id);
+        $this->assertEquals($createdcategory->contextid, $this->context->id);
         $parentcategory = $DB->get_record('question_categories',
-                                          ['name' => 'top', 'contextid' => $context->id],
+                                          ['name' => 'top', 'contextid' => $this->context->id],
                                           '*',
                                           $strictness = MUST_EXIST);
         $this->assertEquals($createdcategory->parent, $parentcategory->id);
@@ -252,7 +282,7 @@ final class import_question_test extends externallib_advanced_testcase {
         $this->assertEquals($createdcategory->info, '');
 
         $createdsubcategory = $DB->get_record('question_categories', ['name' => 'subcat 2_1'], '*', $strictness = MUST_EXIST);
-        $this->assertEquals($createdsubcategory->contextid, $context->id);
+        $this->assertEquals($createdsubcategory->contextid, $this->context->id);
         $this->assertEquals($createdsubcategory->parent, $createdcategory->id);
         $this->assertEquals($createdsubcategory->info, 'Imported subfolder');
 
@@ -278,11 +308,11 @@ final class import_question_test extends externallib_advanced_testcase {
         $createdquestion = $DB->get_record('question', ['name' => 'Third Question'], '*');
         $this->assertEquals($createdquestion, false);
 
-        import_question::execute('', '', '',
-                                 null,
-                                 $this->fileinfo,
-                                 50,
-                                 $this->course->fullname);
+        $returnvalue = import_question::execute('', '', '',
+                                                null,
+                                                $this->fileinfo,
+                                                70,
+                                                $this->course->fullname, $this->module->name);
         $createdsubcategory = $DB->get_record('question_categories', ['name' => 'subcat 2_1'], '*', $strictness = MUST_EXIST);
 
         $sink = $this->redirectEvents();
@@ -290,8 +320,8 @@ final class import_question_test extends externallib_advanced_testcase {
         $returnvalue = import_question::execute('', '', '',
                                                 'top/cat 2/subcat 2_1',
                                                 $this->fileinfo,
-                                                50,
-                                                $this->course->fullname);
+                                                70,
+                                                $this->course->fullname, $this->module->name);
         $createdquestion = $DB->get_record('question', ['name' => 'Third Question'], '*', $strictness = MUST_EXIST);
         $qversion = $DB->get_record('question_versions',
                                     ['questionid' => $createdquestion->id], '*', $strictness = MUST_EXIST);
@@ -334,11 +364,10 @@ final class import_question_test extends externallib_advanced_testcase {
         // Update question.
         $this->upload_file($this->testrepo . 'top/cat-2/subcat-2_1/Third-Question.xml');
         $returnvalue = import_question::execute($qbankentryid, '1', '1',
-                                 null,
-                                 $this->fileinfo,
-                                 50,
-                                 $this->course->fullname);
-
+                                                null,
+                                                $this->fileinfo,
+                                                70,
+                                                $this->course->fullname, $this->module->name);
         // Check version number has increased.
         $this->assertEquals(true, $DB->record_exists('question_versions',
                             ['questionbankentryid' => $qbankentryid, 'version' => 2]));
@@ -377,8 +406,8 @@ final class import_question_test extends externallib_advanced_testcase {
         import_question::execute($qbankentryid, '3', '4',
                                  null,
                                  $this->fileinfo,
-                                 50,
-                                 $this->course->fullname);
+                                 70,
+                                 $this->course->fullname, $this->module->name);
 
         // Check version number has not increased.
         $this->assertEquals(true, $DB->record_exists('question_versions',

--- a/version.php
+++ b/version.php
@@ -35,5 +35,5 @@ $plugin->maturity  = MATURITY_BETA;
 $plugin->release   = '0.10.0 for Moodle 4.1+';
 
 $plugin->dependencies = [
-    'qbank_importasversion'     => 2024041600,
+    'qbank_importasversion'     => 2025041400,
 ];


### PR DESCRIPTION
Hopefully basic compatibility achieved.
- Unit tests updated to always use module context for question banks as that is all Moodle 5 has.
- Use new Moodle default category creation functions where available.
- A little faffing about making sure we have the course id or module id as appropriate.
- Allow modules to be `qbank` as well as 'quiz`. This turns out to be the only essential code divergence between Moodle 4 and Moodle 5 support. The `qbank` DB table is Moodle 5 only.
- Some documentation updates.
- CI updates.

#iss60