### PR TITLE
XML fragments

### DIFF
--- a/classes/cli_helper.php
+++ b/classes/cli_helper.php
@@ -1007,29 +1007,40 @@ class cli_helper {
      * @param string $filepath
      * @param string $tempfilepath Path of main temp file
      * @param string $defaults yml defaults
-     * @return object|null $tempqfilepath
+     * @return object|null|boolean $tempqfilepath else false on error and null if not a STACK question.
      */
-    public static function create_temp_question_file($filepath, $tempfilepath, $defaults) {
+    public static function create_temp_question_file($filepath, $tempfilepath, $defaults, $useyaml) {
         if (!is_file($filepath)) {
             echo "\nRequired question file does not exist: {$filepath}\n";
-            return null;
+            return false;
         }
         $contents = file_get_contents($filepath);
         if ($contents === false) {
             echo "\nUnable to access file: {$filepath}\n";
+            return false;
+        }
+        if (!$useyaml && strpos($contents, '<question type="stack">') === false) {
+            // Non-STACK XML question - not a fragment.
             return null;
         }
         try {
-            $questionxml = yaml_converter::loadyaml($contents, $defaults);
+            libxml_use_internal_errors(true);
+            $questionxml = yaml_converter::loadyaml($contents, $defaults, $useyaml);
+            libxml_use_internal_errors(false);
         } catch (\Exception $e) {
-            echo "\nBroken YAML: {$filepath}\n";
+            echo "\nBroken XML/YAML: {$filepath}\n";
             echo "\n{$e->getMessage()}\n";
-            return null;
+            foreach (libxml_get_errors() as $error) {
+                echo $error->message . "\n";
+            }
+            libxml_clear_errors();
+            libxml_use_internal_errors(false);
+            return false;
         }
         $tempqfilepath = dirname($tempfilepath) . '/tempqfile.tmp';
         $success = file_put_contents($tempqfilepath, $questionxml->asXML());
         if ($success === false) {
-            return null;
+            return false;
         }
         return new \SplFileInfo($tempqfilepath);
     }

--- a/classes/cli_helper.php
+++ b/classes/cli_helper.php
@@ -1019,7 +1019,13 @@ class cli_helper {
             echo "\nUnable to access file: {$filepath}\n";
             return null;
         }
-        $questionxml = yaml_converter::loadyaml($contents, $defaults);
+        try {
+            $questionxml = yaml_converter::loadyaml($contents, $defaults);
+        } catch (\Exception $e) {
+            echo "\nBroken YAML: {$filepath}\n";
+            echo "\n{$e->getMessage()}\n";
+            return null;
+        }
         $tempqfilepath = dirname($tempfilepath) . '/tempqfile.tmp';
         $success = file_put_contents($tempqfilepath, $questionxml->asXML());
         if ($success === false) {

--- a/classes/cli_helper.php
+++ b/classes/cli_helper.php
@@ -54,7 +54,7 @@ class cli_helper {
      * GITSYNC_VERSION - Current version of Gitsync.
      * Should match version in version.php .
      */
-    public const GITSYNC_VERSION = '2025101400';
+    public const GITSYNC_VERSION = '2025111300';
     /**
      * CATEGORY_FILE - Name of file containing category information in each directory and subdirectory.
      */

--- a/classes/cli_helper.php
+++ b/classes/cli_helper.php
@@ -899,10 +899,14 @@ class cli_helper {
                 echo "\nForce import: Importing all questions.\n";
             }
             if (!empty($activity->useyaml)) {
-                echo "\nUsing YAML\n";
+                echo "\nCreating or expecting YAML files.\n";
+            } else {
+                echo "\nCreating or expecting XML files.\n";
             }
             if (!empty($activity->usefragments) && !empty($activity->defaultsfilepath)) {
-                echo "\nUsing fragments with defaults file: " . basename($activity->defaultsfilepath) . "\n";
+                echo "\nCreating or expecting question fragments using defaults file: " . basename($activity->defaultsfilepath) . "\n";
+            } else {
+                echo "\nCreating or expecting full question files not fragments.\n";
             }
             static::handle_abort();
         }
@@ -1025,7 +1029,7 @@ class cli_helper {
         }
         try {
             libxml_use_internal_errors(true);
-            $questionxml = yaml_converter::loadyaml($contents, $defaults, $useyaml);
+            $questionxml = yaml_converter::load_string_as_xml($contents, $defaults, $useyaml);
             libxml_use_internal_errors(false);
         } catch (\Exception $e) {
             echo "\nBroken XML/YAML: {$filepath}\n";

--- a/classes/cli_helper.php
+++ b/classes/cli_helper.php
@@ -71,7 +71,7 @@ class cli_helper {
     /**
      * DEFAULTS_FILE - Default filename for question defaults.
      */
-    public const DEFAULTS_FILE = 'questiondefaults.yml';
+    public const DEFAULTS_FILE = 'questiondefaults.';
     /**
      * TEMP_MANIFEST_FILE - File name ending for temporary manifest file.
      * Appended to name of moodle instance.
@@ -353,7 +353,7 @@ class cli_helper {
                 } else {
                     $variables[$variablename] = $option['default'];
                 }
-                if (in_array($variablename, ['usegit', 'useyaml'])) {
+                if (in_array($variablename, ['usegit', 'useyaml', 'usefragments'])) {
                     $variables[$variablename] = ($variables[$variablename] === 'true') ? true : $variables[$variablename];
                     $variables[$variablename] = ($variables[$variablename] === 'false') ? false : $variables[$variablename];
                 }
@@ -892,8 +892,11 @@ class cli_helper {
             if (!empty($activity->forceimport)) {
                 echo "\nForce import: Importing all questions.\n";
             }
-            if (!empty($activity->useyaml) && !empty($activity->defaultsfilepath)) {
-                echo "\nUsing YAML with defaults file: " . basename($activity->defaultsfilepath) . "\n";
+            if (!empty($activity->useyaml)) {
+                echo "\nUsing YAML\n";
+            }
+            if (!empty($activity->usefragments) && !empty($activity->defaultsfilepath)) {
+                echo "\nUsing fragments with defaults file: " . basename($activity->defaultsfilepath) . "\n";
             }
             static::handle_abort();
         }

--- a/classes/cli_helper.php
+++ b/classes/cli_helper.php
@@ -1023,7 +1023,7 @@ class cli_helper {
             echo "\nUnable to access file: {$filepath}\n";
             return false;
         }
-        if (!$useyaml && strpos($contents, '<question type="stack">') === false) {
+        if (pathinfo($filepath, PATHINFO_EXTENSION) === 'xml' && strpos($contents, '<question type="stack">') === false) {
             // Non-STACK XML question - not a fragment.
             return null;
         }

--- a/classes/cli_helper.php
+++ b/classes/cli_helper.php
@@ -105,18 +105,21 @@ class cli_helper {
         $longopts = $parsed['longopts'];
         $commandlineargs = getopt($shortopts, $longopts);
         $argcount = count($commandlineargs);
-        if (!isset($commandlineargs['w'])) {
-            echo "\nProcessed {$argcount} valid command line argument" .
-                    (($argcount !== 1) ? 's' : '') . ":\n";
-            forEach ($commandlineargs as $option => $value) {
-                $description = strlen($option) > 1 ? $option : $parsed['linked'][$option] . " ({$option})";
-                echo "{$description}: {$value}\n";
-            }
-        }
         $this->processedoptions = $this->prioritise_options($commandlineargs);
         if (!empty($this->processedoptions['help'])) {
             $this->show_help();
             exit;
+        }
+        if (!isset($commandlineargs['w'])) {
+            echo "\nProcessed {$argcount} valid command line argument" .
+                    (($argcount !== 1) ? 's' : '') . ":\n";
+            forEach ($commandlineargs as $option => $value) {
+                $description = strlen($option) > 1 ? $option : $parsed['linked'][$option]['longopt'] . " ({$option})";
+                $argvalue = $this->processedoptions[$parsed['linked'][$option]['variablename']];
+                $argvalue = ($argvalue === false) ? 'false' : $argvalue;
+                $argvalue = ($argvalue === true) ? 'true' : $argvalue;
+                echo "{$description}: {$argvalue}\n";
+            }
         }
         $this->validate_and_clean_args();
         return $this->processedoptions;
@@ -141,7 +144,7 @@ class cli_helper {
             } else {
                 $longopts[] = $option['longopt'];
             }
-            $pairs[$option['shortopt']] = $option['longopt'];
+            $pairs[$option['shortopt']] = ['longopt' => $option['longopt'], 'variablename' => $option['variable']];
         }
 
         return ['shortopts' => $shortopts, 'longopts' => $longopts, 'linked' => $pairs];

--- a/classes/cli_helper.php
+++ b/classes/cli_helper.php
@@ -107,7 +107,11 @@ class cli_helper {
         $argcount = count($commandlineargs);
         if (!isset($commandlineargs['w'])) {
             echo "\nProcessed {$argcount} valid command line argument" .
-                    (($argcount !== 1) ? 's' : '') . ".\n";
+                    (($argcount !== 1) ? 's' : '') . ":\n";
+            forEach ($commandlineargs as $option => $value) {
+                $description = strlen($option) > 1 ? $option : $parsed['linked'][$option] . " ({$option})";
+                echo "{$description}: {$value}\n";
+            }
         }
         $this->processedoptions = $this->prioritise_options($commandlineargs);
         if (!empty($this->processedoptions['help'])) {
@@ -127,6 +131,7 @@ class cli_helper {
     public function parse_options(): array {
         $shortopts = '';
         $longopts = [];
+        $pairs = [];
 
         foreach ($this->options as $option) {
             $shortopts .= $option['shortopt'];
@@ -136,9 +141,10 @@ class cli_helper {
             } else {
                 $longopts[] = $option['longopt'];
             }
+            $pairs[$option['shortopt']] = $option['longopt'];
         }
 
-        return ['shortopts' => $shortopts, 'longopts' => $longopts];
+        return ['shortopts' => $shortopts, 'longopts' => $longopts, 'linked' => $pairs];
     }
 
     /**
@@ -911,13 +917,15 @@ class cli_helper {
      * @return void
      */
     public static function handle_abort(): void {
-        echo "Abort? y/n\n";
+        global $usecontinue;
+        echo ($usecontinue ? "Continue? y/n\n" : "Abort? y/n\n");
         $handle = fopen ("php://stdin", "r");
         $line = fgets($handle);
-        if (trim($line) === 'y') {
-            static::call_exit();
-        }
         fclose($handle);
+        if (($usecontinue && trim($line) === 'y') || (!$usecontinue && trim($line) === 'n')) {
+            return;
+        }
+        static::call_exit();
     }
 
     /**

--- a/classes/create_repo.php
+++ b/classes/create_repo.php
@@ -135,10 +135,16 @@ class create_repo {
     public bool $usegit;
     /**
      * Are we using YAML?.
-     * Set in config. Saves questions as difference file and adds default file to repo.
+     * Set in config. Saves questions as YAML.
      * @var bool
      */
     public bool $useyaml;
+    /**
+     * Are we using fragments?
+     * Set in config. Saves questions as difference file and adds default file to repo.
+     * @var bool
+     */
+    public bool $usefragments;
 
     /**
      * Directory to export into. Will always be null or top.
@@ -172,18 +178,19 @@ class create_repo {
         }
         $this->usegit = $arguments['usegit'];
         $this->useyaml = $arguments['useyaml'];
+        $this->usefragments = $arguments['usefragments'];
         if ($arguments['directory']) {
             $this->directory = ($arguments['rootdirectory']) ?
                     $arguments['rootdirectory'] . '/' . $arguments['directory'] : $arguments['directory'];
         } else {
             $this->directory = $arguments['rootdirectory'];
         }
-        if ($this->useyaml) {
+        if ($this->usefragments) {
             if ($arguments['defaultfile']) {
                 $this->defaultsfilepath = $this->directory . '/' . $arguments['defaultfile'];
-                $this->defaults = yaml_converter::load_defaults($this->defaultsfilepath);
+                $this->defaults = yaml_converter::load_defaults($this->defaultsfilepath, $this->useyaml);
             } else {
-                $this->defaultsfilepath = $this->directory . '/' . cli_helper::DEFAULTS_FILE;
+                $this->defaultsfilepath = $this->directory . '/' . cli_helper::DEFAULTS_FILE . ($this->useyaml ? 'yml' : 'xml');
             }
         }
         if (!empty($arguments['nonquizmanifestpath'])) {
@@ -306,11 +313,14 @@ class create_repo {
      * @return void
      */
     public function process(): void {
-        if (!isset($this->defaults) && $this->useyaml) {
+        if (!isset($this->defaults) && $this->useyaml && $this->usefragments) {
             // This occurs when creating whole course repo. We have had
             // to wait until the course directory has been created.
-            copy(__DIR__ . '/../questiondefaults.yml', $this->defaultsfilepath);
-            $this->defaults = yaml_converter::load_defaults($this->defaultsfilepath);
+            copy(__DIR__ . '/../' . cli_helper::DEFAULTS_FILE . 'yml', $this->defaultsfilepath);
+            $this->defaults = yaml_converter::load_defaults($this->defaultsfilepath, true);
+        } else if (!isset($this->defaults) && $this->usefragments) {
+            copy(__DIR__ . '/../' . cli_helper::DEFAULTS_FILE . 'xml', $this->defaultsfilepath);
+            $this->defaults = yaml_converter::load_defaults($this->defaultsfilepath, false);
         }
         $this->export_to_repo();
         $this->manifestcontents->context->defaultsubdirectory = $this->subdirectory;
@@ -357,7 +367,7 @@ class create_repo {
             $instanceid = $quiz->instanceid;
             $quizdirectory = cli_helper::get_quiz_directory($basedirectory, $quiz->name);
             $rootdirectory = $clihelper->create_directory($quizdirectory);
-            if ($this->useyaml) {
+            if ($this->usefragments) {
                 copy($this->defaultsfilepath, $rootdirectory . '/' . basename($this->defaultsfilepath));
             }
             echo "\nExporting quiz: {$quiz->name} to {$rootdirectory}\n";
@@ -405,7 +415,7 @@ class create_repo {
         chdir($scriptdirectory);
         $usegit = ($this->usegit) ? 'true' : 'false';
         $useyaml = ($this->useyaml) ? 'true' : 'false';
-        $defaults = ($this->useyaml) ? ' -o "' . basename($this->defaultsfilepath) . '"' : '';
+        $defaults = ($this->usefragments) ? ' -b true -o "' . basename($this->defaultsfilepath) . '"' : '';
         return shell_exec('php createrepo.php -u ' . $usegit . ' -w -r "' .
                 $rootdirectory .  '" -i "' . $moodleinstance .
                 '" -l "module" -n ' . $instanceid . ' -t ' . $token . $ignorecat . ' -y ' . $useyaml . $defaults);

--- a/classes/export_repo.php
+++ b/classes/export_repo.php
@@ -361,15 +361,21 @@ class export_repo {
                     echo "{$questioninfo->filepath} not updated.\n";
                     continue;
                 }
-
-                if (strpos($question, '<question type="stack">') !== false) {
-                    if ($this->usefragments) {
-                        $question = yaml_converter::detect_differences($question, $this->defaults, $this->useyaml);
-                    } else {
-                        if ($this->useyaml) {
-                            $question = yaml_converter::xmlstring_to_yamlstring($question);
+                try {
+                    if (strpos($question, '<question type="stack">') !== false) {
+                        if ($this->usefragments) {
+                            $question = yaml_converter::detect_differences($question, $this->defaults, $this->useyaml);
+                        } else {
+                            if ($this->useyaml) {
+                                $question = yaml_converter::xmlstring_to_yamlstring($question);
+                            }
                         }
                     }
+                } catch (\Exception $e) {
+                    echo "\nParsing issue.\n";
+                    echo "\n{$e->getMessage()}\n";
+                    echo "{$questioninfo->filepath} not updated.\n";
+                    continue;
                 }
                 $success = file_put_contents(dirname($this->manifestpath) . $questioninfo->filepath, $question);
                 if ($success === false) {

--- a/classes/export_repo.php
+++ b/classes/export_repo.php
@@ -130,10 +130,16 @@ class export_repo {
     public bool $usegit;
     /**
      * Are we using YAML?.
-     * Set in config. Saves questions as difference file and adds default file to repo.
+     * Set in config. Saves questions as YAML.
      * @var bool
      */
     public bool $useyaml;
+    /**
+     * Are we using fragments?
+     * Set in config. Saves questions as difference file and adds default file to repo.
+     * @var bool
+     */
+    public bool $usefragments;
 
     /**
      * Constructor
@@ -154,6 +160,7 @@ class export_repo {
         }
         $this->usegit = $arguments['usegit'];
         $this->useyaml = $arguments['useyaml'];
+        $this->usefragments = $arguments['usefragments'];
         $defaultwarning = false;
         if ($arguments['manifestpath']) {
             $this->manifestpath = ($arguments['rootdirectory']) ? $arguments['rootdirectory'] . '/' . $arguments['manifestpath'] :
@@ -189,18 +196,19 @@ class export_repo {
             }
         }
 
-        if ($this->useyaml) {
+        if ($this->usefragments) {
+            $defaultsfilename = cli_helper::DEFAULTS_FILE . ($this->useyaml ? 'yml' : 'xml');
             if ($arguments['defaultfile']) {
                 $this->defaultsfilepath = dirname($this->manifestpath) . '/' . $arguments['defaultfile'];
             } else if (!empty($this->manifestcontents->context->defaultdefaults)) {
                 $this->defaultsfilepath = dirname($this->manifestpath) . '/' . $this->manifestcontents->context->defaultdefaults;
-            } else if (is_file(dirname($this->manifestpath) . '/' . cli_helper::DEFAULTS_FILE)) {
-                $this->defaultsfilepath = dirname($this->manifestpath) . '/' . cli_helper::DEFAULTS_FILE;
+            } else if (is_file(dirname($this->manifestpath) . '/' . $defaultsfilename)) {
+                $this->defaultsfilepath = dirname($this->manifestpath) . '/' . $defaultsfilename;
             } else {
-                $this->defaultsfilepath = dirname($this->manifestpath) . '/' . cli_helper::DEFAULTS_FILE;
-                copy(__DIR__ . '/../questiondefaults.yml', $this->defaultsfilepath);
+                $this->defaultsfilepath = dirname($this->manifestpath) . '/' . $defaultsfilename;
+                copy(__DIR__ . '/../' . $defaultsfilename, $this->defaultsfilepath);
             }
-            $this->defaults = yaml_converter::load_defaults($this->defaultsfilepath);
+            $this->defaults = yaml_converter::load_defaults($this->defaultsfilepath, $this->useyaml);
         }
 
         if ($arguments['subcategory']) {
@@ -354,8 +362,14 @@ class export_repo {
                     continue;
                 }
 
-                if ($this->useyaml && strpos($question, '<question type="stack">') !== false) {
-                    $question = yaml_converter::detect_differences($question, $this->defaults);
+                if (strpos($question, '<question type="stack">') !== false) {
+                    if ($this->usefragments) {
+                        $question = yaml_converter::detect_differences($question, $this->defaults, $this->useyaml);
+                    } else {
+                        if ($this->useyaml) {
+                            $question = yaml_converter::xmlstring_to_yamlstring($question);
+                        }
+                    }
                 }
                 $success = file_put_contents(dirname($this->manifestpath) . $questioninfo->filepath, $question);
                 if ($success === false) {
@@ -415,7 +429,7 @@ class export_repo {
                     echo "\nUnable to update manifest file: {$this->manifestpath}\n Aborting.\n";
                     exit();
                 }
-                if ($this->useyaml) {
+                if ($this->usefragments) {
                     copy($this->defaultsfilepath, $rootdirectory . '/' . basename($this->defaultsfilepath));
                 }
                 echo "\nExporting quiz: {$quiz->name} to {$rootdirectory}\n";
@@ -427,7 +441,7 @@ class export_repo {
                 mkdir($rootdirectory);
                 mkdir($rootdirectory . '/top');
                 echo "\nExporting quiz: {$quiz->name} to {$rootdirectory}\n";
-                if ($this->useyaml) {
+                if ($this->usefragments) {
                     copy($this->defaultsfilepath, $rootdirectory . '/' . basename($this->defaultsfilepath));
                 }
                 $output = $this->call_repo_creation($rootdirectory, $moodleinstance,
@@ -435,7 +449,7 @@ class export_repo {
             } else {
                 $rootdirectory = dirname($basedirectory) . '/' . $locarray[$instanceid]->directory;
                 echo "\nExporting quiz: {$quiz->name} to {$rootdirectory}\n";
-                if ($this->useyaml) {
+                if ($this->usefragments) {
                     copy($this->defaultsfilepath, $rootdirectory . '/' . basename($this->defaultsfilepath));
                 }
                 $quizmanifestname = cli_helper::get_manifest_path($moodleinstance, 'module', null,
@@ -467,7 +481,7 @@ class export_repo {
         chdir($scriptdirectory);
         $usegit = ($this->usegit) ? 'true' : 'false';
         $useyaml = ($this->useyaml) ? 'true' : 'false';
-        $defaults = ($this->useyaml) ? ' -o "' . basename($this->defaultsfilepath) . '"' : '';
+        $defaults = ($this->usefragments) ? ' -b true -o "' . basename($this->defaultsfilepath) . '"' : '';
         return shell_exec('php createrepo.php -u ' . $usegit . ' -w -r "' . $rootdirectory .  '" -i "' . $moodleinstance .
                 '" -l "module" -n ' . $instanceid . ' -t ' . $token . $ignorecat . ' -y ' . $useyaml . $defaults);
     }
@@ -488,7 +502,7 @@ class export_repo {
         chdir($scriptdirectory);
         $usegit = ($this->usegit) ? 'true' : 'false';
         $useyaml = ($this->useyaml) ? 'true' : 'false';
-        $defaults = ($this->useyaml) ? ' -o "' . basename($this->defaultsfilepath) . '"' : '';
+        $defaults = ($this->usefragments) ? ' -b true -o "' . basename($this->defaultsfilepath) . '"' : '';
         return shell_exec('php exportrepofrommoodle.php -u ' . $usegit . ' -w -r "' . $rootdirectory . '" -i "' .
                             $moodleinstance . '" -f "' . $quizmanifestname . '" -t ' . $token . $ignorecat .
                             ' -y ' . $useyaml . $defaults);

--- a/classes/export_trait.php
+++ b/classes/export_trait.php
@@ -236,9 +236,17 @@ trait export_trait {
                     }
                 }
                 $filetype = 'xml';
-                if ($this->useyaml && strpos($question, '<question type="stack">') !== false) {
-                    $question = yaml_converter::detect_differences($question, $this->defaults);
-                    $filetype = 'yml';
+                if (strpos($question, '<question type="stack">') !== false) {
+                    if ($this->useyaml) {
+                        $filetype = 'yml';
+                    }
+                    if ($this->usefragments) {
+                        $question = yaml_converter::detect_differences($question, $this->defaults, $this->useyaml);
+                    } else {
+                        if ($this->useyaml) {
+                            $question = yaml_converter::xmlstring_to_yamlstring($question);
+                        }
+                    }
                 }
 
                 $sanitisedqname = preg_replace(cli_helper::BAD_CHARACTERS, '-', substr($qname, 0, $this->maxqlength));
@@ -258,7 +266,7 @@ trait export_trait {
                     'questionbankentryid' => $questioninfo->questionbankentryid,
                     'version' => $responsejson->version,
                     'filepath' => str_replace( '\\', '/', $bottomdirectory) . "/{$sanitisedqname}.{$filetype}",
-                    'format' => 'xml',
+                    'format' => $filetype,
                 ];
                 fwrite($tempfile, json_encode($fileoutput) . "\n");
             }

--- a/classes/export_trait.php
+++ b/classes/export_trait.php
@@ -236,17 +236,25 @@ trait export_trait {
                     }
                 }
                 $filetype = 'xml';
-                if (strpos($question, '<question type="stack">') !== false) {
-                    if ($this->useyaml) {
-                        $filetype = 'yml';
-                    }
-                    if ($this->usefragments) {
-                        $question = yaml_converter::detect_differences($question, $this->defaults, $this->useyaml);
-                    } else {
+                try {
+                    if (strpos($question, '<question type="stack">') !== false) {
                         if ($this->useyaml) {
-                            $question = yaml_converter::xmlstring_to_yamlstring($question);
+                            $filetype = 'yml';
+                        }
+                        if ($this->usefragments) {
+                            $question = yaml_converter::detect_differences($question, $this->defaults, $this->useyaml);
+                        } else {
+                            if ($this->useyaml) {
+                                $question = yaml_converter::xmlstring_to_yamlstring($question);
+                            }
                         }
                     }
+                } catch (\Exception $e) {
+                    echo "\nParsing issue.\n";
+                    echo "\n{$e->getMessage()}\n";
+                    echo "\nFile creation or update unsuccessful:\n";
+                    echo "{$bottomdirectory}/{$sanitisedqname}.{$filetype}";
+                    continue;
                 }
 
                 $sanitisedqname = preg_replace(cli_helper::BAD_CHARACTERS, '-', substr($qname, 0, $this->maxqlength));

--- a/classes/export_trait.php
+++ b/classes/export_trait.php
@@ -252,8 +252,7 @@ trait export_trait {
                 } catch (\Exception $e) {
                     echo "\nParsing issue.\n";
                     echo "\n{$e->getMessage()}\n";
-                    echo "\nFile creation or update unsuccessful:\n";
-                    echo "{$bottomdirectory}/{$sanitisedqname}.{$filetype}";
+                    echo "\nQuestion: {$qname}\n";
                     continue;
                 }
 

--- a/classes/external/import_question.php
+++ b/classes/external/import_question.php
@@ -206,8 +206,16 @@ class import_question extends external_api {
             throw new moodle_exception('importerror', 'qbank_gitsync', null, $filename);
         }
 
+        $errors = '';
+        $notices = '';
         if ($params['questionbankentryid']) {
-            \qbank_importasversion\importer::import_file($qformat, $question, $tempfile);
+            try {
+                $result = \qbank_importasversion\importer::import_file($qformat, $question, $tempfile);
+                $errors = $result->error ?? '';
+                $notices = $result->notice ?? '';
+            } catch (Exception $e) {
+                $errors = $e->getMessage();
+            }
         } else {
             if (!$qformat->importprocess()) {
                 throw new moodle_exception('importerror', 'qbank_gitsync', null, $filename);

--- a/classes/external/import_question.php
+++ b/classes/external/import_question.php
@@ -81,6 +81,7 @@ class import_question extends external_api {
         return new external_single_structure([
             'questionbankentryid' => new external_value(PARAM_SEQUENCE, 'questionbankentry id'),
             'version' => new external_value(PARAM_SEQUENCE, 'question version'),
+            'validation' => new external_value(PARAM_RAW, 'validation issues'),
         ]);
     }
 
@@ -209,12 +210,11 @@ class import_question extends external_api {
         $errors = '';
         $notices = '';
         if ($params['questionbankentryid']) {
-            try {
-                $result = \qbank_importasversion\importer::import_file($qformat, $question, $tempfile);
-                $errors = $result->error ?? '';
-                $notices = $result->notice ?? '';
-            } catch (Exception $e) {
-                $errors = $e->getMessage();
+            $result = \qbank_importasversion\importer::import_file($qformat, $question, $tempfile);
+            $errors = $result->error ?? '';
+            $notices = $result->notice ?? '';
+            if ($errors) {
+                throw new moodle_exception('importerror' . '', 'qbank_gitsync', null, $filename, $errors);
             }
         } else {
             if (!$qformat->importprocess()) {
@@ -231,6 +231,7 @@ class import_question extends external_api {
         $response = new \stdClass();
         $response->questionbankentryid = null;
         $response->version = null;
+        $response->validation = $notices;
         // Log imported question and return id of new question ready to make manifest file.
         if (!$params['questionbankentryid'] && !$iscategory) {
             $eventparams = [

--- a/classes/external/import_question.php
+++ b/classes/external/import_question.php
@@ -254,6 +254,7 @@ class import_question extends external_api {
                 ['questionbankentryid' => $response->questionbankentryid]
             );
         }
+        ob_clean();
         return $response;
     }
 }

--- a/classes/import_quiz.php
+++ b/classes/import_quiz.php
@@ -128,10 +128,16 @@ class import_quiz {
     public bool $usegit;
     /**
      * Are we using YAML?.
-     * Set in config. Saves questions as difference file and adds default file to repo.
+     * Set in config. Saves questions as YAML.
      * @var bool
      */
     public bool $useyaml;
+    /**
+     * Are we using fragments?
+     * Set in config. Saves questions as difference file and adds default file to repo.
+     * @var bool
+     */
+    public bool $usefragments;
     /**
      * Commit all questions?
      * @var bool
@@ -163,6 +169,7 @@ class import_quiz {
         $contextlevel = cli_helper::get_context_level('course');
         $this->usegit = $arguments['usegit'];
         $this->useyaml = isset($arguments['useyaml']) ? $arguments['useyaml'] : false;
+        $this->usefragments = isset($arguments['usefragments']) ? $arguments['usefragments'] : false;
         if (!empty($arguments['quizmanifestpath'])) {
             $this->quizmanifestpath = ($arguments['quizmanifestpath']) ?
                                 $directoryprefix . $arguments['quizmanifestpath'] : null;
@@ -360,18 +367,19 @@ class import_quiz {
         $ignorecat = ($ignorecat) ? ' -x "' . $ignorecat . '"' : '';
         $this->import_quiz_data();
         if ($this->useyaml) {
+            $defaultsfilename = cli_helper::DEFAULTS_FILE . ($this->useyaml ? 'yml' : 'xml');
             if ($arguments['defaultfile']) {
                 $this->defaultsfilepath = dirname($this->quizmanifestpath) . '/' . $arguments['defaultfile'];
             } else if (!empty($this->quizmanifestcontents->context->defaultdefaults)) {
                 $this->defaultsfilepath = dirname($this->quizmanifestpath) . '/' .
                 $this->quizmanifestcontents->context->defaultdefaults;
-            } else if (is_file(dirname($this->quizmanifestpath) . '/' . cli_helper::DEFAULTS_FILE)) {
-                $this->defaultsfilepath = dirname($this->quizmanifestpath) . '/' . cli_helper::DEFAULTS_FILE;
+            } else if (is_file(dirname($this->quizmanifestpath) . '/' . $defaultsfilename)) {
+                $this->defaultsfilepath = dirname($this->quizmanifestpath) . '/' . $defaultsfilename;
             } else {
-                $this->defaultsfilepath = dirname($this->quizmanifestpath) . '/' . cli_helper::DEFAULTS_FILE;
-                copy(__DIR__ . '/../questiondefaults.yml', $this->defaultsfilepath);
+                $this->defaultsfilepath = dirname($this->quizmanifestpath) . '/' . $defaultsfilename;
+                copy(__DIR__ . '/../' . $defaultsfilename, $this->defaultsfilepath);
             }
-            $this->defaults = yaml_converter::load_defaults($this->defaultsfilepath);
+            $this->defaults = yaml_converter::load_defaults($this->defaultsfilepath, $this->useyaml);
         }
         $output = $this->call_import_repo($directory, $moodleinstance, $token,
                         $this->cmid, $ignorecat, $scriptdirectory);
@@ -397,7 +405,7 @@ class import_quiz {
         $usegit = ($this->usegit) ? 'true' : 'false';
         $useyaml = ($this->useyaml) ? 'true' : 'false';
         $forceimport = ($this->forceimport) ? ' -z' : '';
-        $defaults = ($this->useyaml) ? ' -o "' . basename($this->defaultsfilepath) . '"' : '';
+        $defaults = ($this->usefragments) ? ' -b true -o "' . basename($this->defaultsfilepath) . '"' : '';
         return shell_exec('php importrepotomoodle.php -u ' . $usegit . ' -w -r "' . $rootdirectory .
                         '" -i "' . $moodleinstance . '" -l "module" -n ' . $quizcmid . ' -t ' . $token .
                         $ignorecat . ' -y ' . $useyaml . $defaults . $forceimport);
@@ -535,12 +543,14 @@ class import_quiz {
      * @return void
      */
     public function handle_abort(): void {
-        echo "Abort? y/n\n";
+        global $usecontinue;
+        echo ($usecontinue ? "Continue? y/n\n" : "Abort? y/n\n");
         $handle = fopen ("php://stdin", "r");
         $line = fgets($handle);
-        if (trim($line) === 'y') {
-            $this->call_exit();
-        }
         fclose($handle);
+        if (($usecontinue && trim($line) === 'y') || (!$usecontinue && trim($line) === 'n')) {
+            return;
+        }
+        $this->call_exit();
     }
 }

--- a/classes/import_repo.php
+++ b/classes/import_repo.php
@@ -790,7 +790,7 @@ class import_repo {
                             $tempqfile = cli_helper::create_temp_question_file(
                                 $repoitem,
                                 $this->tempfilepath,
-                                $this->defaults,
+                                ($this->usefragments) ? $this->defaults : null,
                                 $this->useyaml
                             );
                             if ($tempqfile === false) {

--- a/classes/import_repo.php
+++ b/classes/import_repo.php
@@ -188,10 +188,16 @@ class import_repo {
     public ?array $defaults;
     /**
      * Are we using YAML?.
-     * Set in config. Saves questions as difference file and adds default file to repo.
+     * Set in config. Saves questions as YAML.
      * @var bool
      */
     public bool $useyaml;
+    /**
+     * Are we using fragments?
+     * Set in config. Saves questions as difference file and adds default file to repo.
+     * @var bool
+     */
+    public bool $usefragments;
     /**
      * Commit all questions?
      * @var bool
@@ -238,6 +244,7 @@ class import_repo {
         $this->ignorecat = $arguments['ignorecat'];
         $this->usegit = $arguments['usegit'];
         $this->useyaml = isset($arguments['useyaml']) ? $arguments['useyaml'] : false;
+        $this->usefragments = isset($arguments['usefragments']) ? $arguments['usefragments'] : false;
 
         $this->moodleurl = $moodleinstances[$moodleinstance];
         $wsurl = $this->moodleurl . '/webservice/rest/server.php';
@@ -346,18 +353,19 @@ class import_repo {
             $this->call_exit();
         }
 
-        if ($this->useyaml) {
+        if ($this->usefragments) {
+            $defaultsfilename = cli_helper::DEFAULTS_FILE . ($this->useyaml ? 'yml' : 'xml');
             if ($arguments['defaultfile']) {
                 $this->defaultsfilepath = $this->directory . '/' . $arguments['defaultfile'];
             } else if (!empty($manifestcontents->context->defaultdefaults)) {
                 $this->defaultsfilepath = $this->directory . '/' . $manifestcontents->context->defaultdefaults;
-            } else if (is_file(dirname($this->manifestpath) . '/' . cli_helper::DEFAULTS_FILE)) {
-                $this->defaultsfilepath = $this->directory . '/' . cli_helper::DEFAULTS_FILE;
+            } else if (is_file(dirname($this->manifestpath) . '/' . $defaultsfilename)) {
+                $this->defaultsfilepath = $this->directory . '/' . $defaultsfilename;
             } else {
-                $this->defaultsfilepath = $this->directory . '/' . cli_helper::DEFAULTS_FILE;
-                copy($this->directory . '/../questiondefaults.yml', $this->defaultsfilepath);
+                $this->defaultsfilepath = $this->directory . '/' . $defaultsfilename;
+                copy($this->directory . '/../' . $defaultsfilename, $this->defaultsfilepath);
             }
-            $this->defaults = yaml_converter::load_defaults($this->defaultsfilepath);
+            $this->defaults = yaml_converter::load_defaults($this->defaultsfilepath, $this->useyaml);
         }
         if (!$manifestcontents && $manifestpath) {
             echo "\nManifest file is empty: {$this->manifestpath}\n";
@@ -1002,13 +1010,15 @@ class import_repo {
      * @return void
      */
     public function handle_abort(): void {
-        echo "Abort? y/n\n";
+        global $usecontinue;
+        echo ($usecontinue ? "Continue? y/n\n" : "Abort? y/n\n");
         $handle = fopen ("php://stdin", "r");
         $line = fgets($handle);
-        if (trim($line) === 'y') {
-            $this->call_exit();
-        }
         fclose($handle);
+        if (($usecontinue && trim($line) === 'y') || (!$usecontinue && trim($line) === 'n')) {
+            return;
+        }
+        $this->call_exit();
     }
 
     /**
@@ -1253,8 +1263,8 @@ class import_repo {
         $usegit = ($this->usegit) ? 'true' : 'false';
         $useyaml = ($this->useyaml) ? 'true' : 'false';
         $forceimport = ($this->forceimport) ? ' -z' : '';
-        $defaults = ($this->useyaml) ? ' -o "' . basename($this->defaultsfilepath) . '"' : '';
-        if ($this->useyaml) {
+        $defaults = ($this->usefragments) ? ' -b true -o "' . basename($this->defaultsfilepath) . '"' : '';
+        if ($this->usefragments) {
             copy($this->defaultsfilepath, $rootdirectory . '/' . basename($this->defaultsfilepath));
         }
         chdir($scriptdirectory);

--- a/classes/import_repo.php
+++ b/classes/import_repo.php
@@ -835,7 +835,7 @@ class import_repo {
                                 $fileoutput['currentcommit'] = $commithash;
                             }
                             fwrite($tempfile, json_encode($fileoutput) . "\n");
-                            if ($responsejson->validation) {
+                            if (!empty($responsejson->validation)) {
                                 echo "\n{$repoitem->getPathname()} imported but has validation issues. Please exportrepofrommoodle to identify any changes which have been made.\n";
                                 echo "{$responsejson->validation}\n";
                             }

--- a/classes/import_repo.php
+++ b/classes/import_repo.php
@@ -784,10 +784,16 @@ class import_repo {
                             $this->postsettings['exportedversion'] = null;
                         }
                         $tempqfile = null;
-                        if (pathinfo($repoitem, PATHINFO_EXTENSION) === 'yml') {
-                            $tempqfile = cli_helper::create_temp_question_file($repoitem, $this->tempfilepath, $this->defaults);
-                            if (!$tempqfile) {
-                                echo 'File upload problem.\n';
+                        if (pathinfo($repoitem, PATHINFO_EXTENSION) === 'yml' || $this->usefragments) {
+                            // YAML files always need conversion. XML need conversion if fragments of STACK questions.
+                            // We don't have file contents yet so can't check question type here.
+                            $tempqfile = cli_helper::create_temp_question_file(
+                                $repoitem,
+                                $this->tempfilepath,
+                                $this->defaults,
+                                $this->useyaml
+                            );
+                            if ($tempqfile === false) {
                                 echo "{$repoitem->getPathname()} not imported.\n";
                                 continue;
                             }

--- a/classes/import_repo.php
+++ b/classes/import_repo.php
@@ -835,6 +835,10 @@ class import_repo {
                                 $fileoutput['currentcommit'] = $commithash;
                             }
                             fwrite($tempfile, json_encode($fileoutput) . "\n");
+                            if ($responsejson->validation) {
+                                echo "\n{$repoitem->getPathname()} imported but has validation issues. Please exportrepofrommoodle to identify any changes which have been made.\n";
+                                echo "{$responsejson->validation}\n";
+                            }
                         }
                     } else {
                         echo "Problem with the category file or file location.\n" .

--- a/classes/yaml_converter.php
+++ b/classes/yaml_converter.php
@@ -80,7 +80,7 @@ class yaml_converter {
         if ($defaults) {
             self::$defaults = $defaults;
         } else {
-            self::$defaults = self::load_defaults(__DIR__ . '/../questiondefaults.yml');
+            self::$defaults = self::load_defaults(__DIR__ . '/../questiondefaults.yml', true);
         }
         try {
             $xmldata = self::yamlstring_to_xml($yaml);
@@ -629,7 +629,7 @@ class yaml_converter {
         if ($defaults) {
             self::$defaults = $defaults;
         } else {
-            self::$defaults = self::load_defaults(__DIR__ . '/../questiondefaults.yml');
+            self::$defaults = self::load_defaults(__DIR__ . '/../' . cli_helper::DEFAULTS_FILE . ($useyaml ? 'yml' : 'xml'));
         }
         if (strpos($xml, '<question type="stack">') !== false || !$useyaml) {
             $xmldata = new SimpleXMLElement($xml);

--- a/classes/yaml_converter.php
+++ b/classes/yaml_converter.php
@@ -76,7 +76,7 @@ class yaml_converter {
     }
 
     // phpcs:ignore moodle.Commenting.MissingDocblock.Function
-    public static function loadyaml($data, $defaults, $useyaml = true) {
+    public static function load_string_as_xml($data, $defaults, $useyaml = true) {
         if ($defaults) {
             self::$defaults = $defaults;
         } else {
@@ -98,7 +98,7 @@ class yaml_converter {
             self::set_field($question, 'questiontext->text', self::get_default('question', 'questiontext'));
         }
         if (!isset($question->questiontext['format'])) {
-            self::get_default('question', 'questiontextformat');
+            $question->questiontext['format'] = self::get_default('question', 'questiontextformat');
         }
         if (!isset($question->generalfeedback->text)) {
             self::set_field($question, 'generalfeedback->text', self::get_default('question', 'generalfeedback'));
@@ -162,6 +162,9 @@ class yaml_converter {
         if (!(array) $question->isbroken) {
             self::set_field($question, 'isbroken', self::get_default('question', 'isbroken'));
         }
+        if (!(array) $question->hidden) {
+            self::set_field($question, 'hidden', self::get_default('question', 'hidden'));
+        }
         if (!(array) $question->multiplicationsign) {
             self::set_field($question, 'multiplicationsign', self::get_default('question', 'multiplicationsign'));
         }
@@ -181,10 +184,10 @@ class yaml_converter {
             self::set_field($question, 'sqrtsign', self::get_default('question', 'sqrtsign'));
         }
         if (!(array) $question->questionsimplify) {
-            self::set_field($question, 'simplify', self::get_default('question', 'questionsimplify'));
+            self::set_field($question, 'questionsimplify', self::get_default('question', 'questionsimplify'));
         }
         if (!(array) $question->assumepositive) {
-            self::set_field($question, 'assumepos', self::get_default('question', 'assumepositive'));
+            self::set_field($question, 'assumepositive', self::get_default('question', 'assumepositive'));
         }
         if (!(array) $question->assumereal) {
             self::set_field($question, 'assumereal', self::get_default('question', 'assumereal'));
@@ -196,15 +199,22 @@ class yaml_converter {
             self::set_field($question, 'scientificnotation', self::get_default('question', 'scientificnotation'));
         }
 
+        if ($question->defaultgrade && (!$question->input || !count($question->input))) {
+            self::set_field($question, 'input->0', '');
+        }
+
         foreach ($question->input as $inputdata) {
             if (!(array) $inputdata->name) {
-                self::set_field($inputdata, 'name', self::get_default('input', 'type'));
+                self::set_field($inputdata, 'name', self::get_default('input', 'name'));
             }
             if (!(array) $inputdata->type) {
                 self::set_field($inputdata, 'type', self::get_default('input', 'type'));
             }
             if (!(array) $inputdata->tans) {
                 self::set_field($inputdata, 'tans', self::get_default('input', 'tans'));
+            }
+            if (!(array) $inputdata->strictsyntax) {
+                self::set_field($inputdata, 'strictsyntax', self::get_default('input', 'strictsyntax'));
             }
             if (!(array) $inputdata->boxsize) {
                 self::set_field($inputdata, 'boxsize', self::get_default('input', 'boxsize'));
@@ -244,6 +254,10 @@ class yaml_converter {
             }
         }
 
+        if ($question->defaultgrade && (!$question->prt || !count($question->prt))) {
+            self::set_field($question, 'prt->0', '');
+        }
+
         foreach ($question->prt as $prtdata) {
             if (!(array) $prtdata->name) {
                 self::set_field($prtdata, 'name', self::get_default('prt', 'name'));
@@ -261,6 +275,10 @@ class yaml_converter {
                 self::set_field($prtdata, 'feedbackvariables->text', self::get_default('prt', 'feedbackvariables'));
             }
 
+            if (!$prtdata->node || !count($prtdata->node)) {
+                self::set_field($prtdata, 'node', '');
+            }
+
             foreach ($prtdata->node as $node) {
                 if (!isset($node->name)) {
                     self::set_field($node, 'name', self::get_default('node', 'name'));
@@ -272,7 +290,7 @@ class yaml_converter {
                     self::set_field($node, 'answertest', self::get_default('node', 'answertest'));
                 }
                 if (!isset($node->sans)) {
-                    self::set_field($node, 'sans', self::get_default('node', 'sand'));
+                    self::set_field($node, 'sans', self::get_default('node', 'sans'));
                 }
                 if (!isset($node->tans)) {
                     self::set_field($node, 'tans', self::get_default('node', 'tans'));
@@ -441,13 +459,13 @@ class yaml_converter {
      *
      * @param string $yamlstring The YAML string to convert.
      * @return SimpleXMLElement The resulting XML object.
-     * @throws \stack_exception If the YAML string is invalid.
+     * @throws \Exception If the YAML string is invalid.
      */
     public static function yamlstring_to_xml($yamlstring) {
         self::require_yaml();
         $yaml = Yaml::parse($yamlstring);
         if (!$yaml) {
-            throw new \stack_exception("The provided file does not contain valid YAML or XML.");
+            throw new \Exception("The provided file does not contain valid YAML or XML.");
         }
         $xml = self::yaml_to_xml($yaml);
         return $xml;
@@ -813,7 +831,7 @@ class yaml_converter {
      * @param string $value The value to add as CDATA.
      */
     public static function add_cdata(&$xml, $value) {
-        if (!empty($value) && htmlspecialchars($value, ENT_COMPAT) != $value) {
+        if (!empty($value) && $value&& htmlspecialchars($value, ENT_COMPAT) != $value) {
             $node = dom_import_simplexml($xml);
             $no = $node->ownerDocument;
             $node->appendChild($no->createCDATASection($value));

--- a/classes/yaml_converter.php
+++ b/classes/yaml_converter.php
@@ -199,7 +199,7 @@ class yaml_converter {
             self::set_field($question, 'scientificnotation', self::get_default('question', 'scientificnotation'));
         }
 
-        if ($question->defaultgrade && (!$question->input || !count($question->input))) {
+        if ($question->defaultgrade != '0' && (!$question->input || !count($question->input))) {
             self::set_field($question, 'input->0', '');
         }
 
@@ -254,7 +254,7 @@ class yaml_converter {
             }
         }
 
-        if ($question->defaultgrade && (!$question->prt || !count($question->prt))) {
+        if ($question->defaultgrade != '0' && (!$question->prt || !count($question->prt))) {
             self::set_field($question, 'prt->0', '');
         }
 
@@ -352,11 +352,11 @@ class yaml_converter {
                 if (!isset($testinput->name)) {
                     self::set_field($testinput, 'name', self::get_default('testinput', 'name'));
                 }
-                if (!(array) $testinput->value) {
+                if (!isset($testinput->value)) {
                     self::set_field($testinput, 'value', self::get_default('testinput', 'value'));
                 }
             }
-            if (!(array) $test->description) {
+            if (!isset($test->description)) {
                 self::set_field($test, 'description', self::get_default('qtest', 'description'));
             }
             if (!(array) $test->testcase) {
@@ -372,7 +372,7 @@ class yaml_converter {
                 if (!(array) $expected->expectedpenalty) {
                     self::set_field($expected, 'expectedpenalty', self::get_default('expected', 'expectedpenalty'));
                 }
-                if (!(array) $expected->expectedanswernote) {
+                if (!isset($expected->expectedanswernote)) {
                     self::set_field($expected, 'expectedanswernote', self::get_default('expected', 'expectedanswernote'));
                 }
             }
@@ -511,7 +511,7 @@ class yaml_converter {
         // Name is a special case. Has text tag but no format.
         $name = isset($xml->question->name) ? (string) $xml->question->name : self::get_default('question', 'name');
         $xml->question->name = new SimpleXMLElement('<root></root>');
-        $xml->question->name->addChild('text', $name);
+        $xml->question->name->text = $name;
         return $xml;
     }
 
@@ -667,7 +667,7 @@ class yaml_converter {
                 $diffinputs[] = $diffinput;
             }
             $diff['input'] = $diffinputs;
-        } else if (!isset($plaindata['question']['defaultgrade']) || $plaindata['question']['defaultgrade']) {
+        } else if (!isset($plaindata['question']['defaultgrade']) || $plaindata['question']['defaultgrade'] != '0') {
             $diff['input'] = [['name' => self::get_default('input', 'name'),
                 'type' => self::get_default('input', 'type'),
                 'tans' => self::get_default('input', 'tans'),
@@ -707,7 +707,7 @@ class yaml_converter {
                 $diffprts[] = $diffprt;
             }
             $diff['prt'] = $diffprts;
-        } else if (!isset($plaindata['question']['defaultgrade']) || $plaindata['question']['defaultgrade']) {
+        } else if (!isset($plaindata['question']['defaultgrade']) || $plaindata['question']['defaultgrade'] != '0') {
             $prtnode = ['name' => self::get_default('node', 'name'),
                     'answertest' => self::get_default('node', 'answertest')];
             if (substr($prtnode['answertest'], 0, 2) !== 'AT') {
@@ -737,13 +737,13 @@ class yaml_converter {
                 $difftest = [];
                 $difftest['testcase'] = $test['testcase'];
                 $difftest = array_merge($difftest, self::obj_diff(self::$defaults['qtest'], $test));
-                foreach ($test['testinput'] as $tinput) {
+                foreach ($test['testinput'] ?? [] as $tinput) {
                     $difftinput = [];
                     $difftinput['name'] = $tinput['name'];
                     $difftinput = array_merge($difftinput, self::obj_diff(self::$defaults['testinput'], $tinput));
                     $difftest['testinput'][] = $difftinput;
                 }
-                foreach ($test['expected'] as $texpected) {
+                foreach ($test['expected'] ?? [] as $texpected) {
                     $difftexpected = [];
                     $difftexpected['name'] = $texpected['name'];
                     $difftexpected = array_merge($difftexpected, self::obj_diff(self::$defaults['expected'], $texpected));
@@ -831,7 +831,7 @@ class yaml_converter {
      * @param string $value The value to add as CDATA.
      */
     public static function add_cdata(&$xml, $value) {
-        if (!empty($value) && $value&& htmlspecialchars($value, ENT_COMPAT) != $value) {
+        if (!empty($value) && $value && htmlspecialchars($value, ENT_COMPAT) != $value) {
             $node = dom_import_simplexml($xml);
             $no = $node->ownerDocument;
             $node->appendChild($no->createCDATASection($value));

--- a/classes/yaml_converter.php
+++ b/classes/yaml_converter.php
@@ -504,14 +504,13 @@ class yaml_converter {
      */
     public static function yaml_to_xml($yaml) {
         $xml = new SimpleXMLElement("<?xml version='1.0' encoding='UTF-8'?><quiz></quiz>");
-        $question = $xml->addChild('question');
-        $question->addAttribute('type', 'stack');
 
-        self::array_to_xml($yaml, $question);
+        self::array_to_xml($yaml, $xml);
         // Name is a special case. Has text tag but no format.
         $name = isset($xml->question->name) ? (string) $xml->question->name : self::get_default('question', 'name');
         $xml->question->name = new SimpleXMLElement('<root></root>');
         $xml->question->name->text = $name;
+        $xml->question->addAttribute('type', 'stack');
         return $xml;
     }
 
@@ -842,11 +841,11 @@ class yaml_converter {
 
     /**
      * Split a string into a 4-item array such that:
-     * 'AAAA(X(X,X)XX, YYY, ZZZ, WWW)'
+     * 'AAAA(X(X,X)XX, YYY[Y,Y], ZZZ, WWW)'
      * becomes:
      * [0] => 'AAAA'
      * [1] => 'X(X,X)XX'
-     * [2] => 'YYY'
+     * [2] => 'YYY[Y,Y]'
      * [3] => 'ZZZ, WWW'
      * @param string $answertest
      * @return array
@@ -854,21 +853,34 @@ class yaml_converter {
     public static function split_answertest($answertest) {
         $result = [];
         $firstbracketpos = strpos($answertest, '(');
+        if ($firstbracketpos === false) {
+            // No brackets found — return original code and empty fields.
+            return [$answertest, '', '', ''];
+        }
         $result[] = substr($answertest, 0, $firstbracketpos);
         $testprops = substr($answertest, $firstbracketpos + 1, strrpos($answertest, ')') - $firstbracketpos - 1);
-        $bracketlevel = 0;
+
+        $parenLevel = 0;
+        $squareLevel = 0;
         $current = '';
         $count = 0;
         $len = strlen($testprops);
         for ($i = 0; $i < $len; $i++) {
             $char = $testprops[$i];
             if ($char === '(') {
-                $bracketlevel++;
+                $parenLevel++;
                 $current .= $char;
             } else if ($char === ')') {
-                $bracketlevel--;
+                $parenLevel--;
                 $current .= $char;
-            } else if ($char === ',' && $bracketlevel === 0 && $count < 2) {
+            } else if ($char === '[') {
+                $squareLevel++;
+                $current .= $char;
+            } else if ($char === ']') {
+                $squareLevel--;
+                $current .= $char;
+            } else if ($char === ',' && $parenLevel === 0 && $squareLevel === 0 && $count < 2) {
+                // Split only on top-level commas (not inside () or []) and only for first two splits.
                 $result[] = trim($current);
                 $current = '';
                 $count++;

--- a/classes/yaml_converter.php
+++ b/classes/yaml_converter.php
@@ -480,7 +480,7 @@ class yaml_converter {
     /**
      * Converts YAML to a SimpleXMLElement object.
      *
-     * @param string $yaml The YAML to convert.
+     * @param [] $yaml The YAML to convert.
      * @return SimpleXMLElement $xml The resulting XML.
      */
     public static function yaml_to_xml($yaml) {
@@ -592,16 +592,22 @@ class yaml_converter {
      * @return array YAML
      */
     public static function load_defaults($defaultfile, $isyaml = true) {
-        if ($isyaml) {
-            self::require_yaml();
-            $defaults = Yaml::parseFile($defaultfile);
-        } else {
-            $xml = file_get_contents($defaultfile);
-            $defaults = new SimpleXMLElement($xml);
-            $defaults = self::xml_to_array($defaults, isdefault: true);
+        try {
+            if ($isyaml) {
+                self::require_yaml();
+                $defaults = Yaml::parseFile($defaultfile);
+            } else {
+                $xml = file_get_contents($defaultfile);
+                $defaults = new SimpleXMLElement($xml);
+                $output = [];
+                $defaults = self::xml_to_array($defaults, $output, true);
+            }
+        } catch (\Exception $e) {
+            $defaults = null;
         }
         if (!$defaults) {
             echo "\nUnable to access or parse default file: {$defaultfile}\nAborting.\n";
+            echo "\n{$e->getMessage()}\n";
             self::call_exit();
         }
         return $defaults;

--- a/classes/yaml_converter.php
+++ b/classes/yaml_converter.php
@@ -76,17 +76,18 @@ class yaml_converter {
     }
 
     // phpcs:ignore moodle.Commenting.MissingDocblock.Function
-    public static function loadyaml($yaml, $defaults) {
+    public static function loadyaml($data, $defaults, $useyaml = true) {
         if ($defaults) {
             self::$defaults = $defaults;
         } else {
             self::$defaults = self::load_defaults(__DIR__ . '/../questiondefaults.yml', true);
         }
-        try {
-            $xmldata = self::yamlstring_to_xml($yaml);
-        } catch (\Exception $e) {
-            throw new \Exception("The provided file does not contain valid YAML");
+        if ($useyaml) {
+            $xmldata = self::yamlstring_to_xml($data);
+        } else {
+            $xmldata = new SimpleXMLElement($data);
         }
+
         $question = $xmldata->question;
 
         // Based on Moodle's base question type.
@@ -607,7 +608,8 @@ class yaml_converter {
         }
         if (!$defaults) {
             echo "\nUnable to access or parse default file: {$defaultfile}\nAborting.\n";
-            echo "\n{$e->getMessage()}\n";
+            echo "{$e->getMessage()}\n";
+            echo "Make sure your 'useyaml' setting is correct for this repo.\n";
             self::call_exit();
         }
         return $defaults;
@@ -625,9 +627,9 @@ class yaml_converter {
     }
 
     /**
-     * Detects differences between the provided XML or YAML and the default question structure.
+     * Detects differences between the provided XML and the default question structure.
      *
-     * @param string $xml The XML or YAML string to compare.
+     * @param string $xml The XML string to compare.
      * @param boolean $useyaml Return YAML? (Rather than XML?).
      * @return string The differences.
      */
@@ -637,11 +639,7 @@ class yaml_converter {
         } else {
             self::$defaults = self::load_defaults(__DIR__ . '/../' . cli_helper::DEFAULTS_FILE . ($useyaml ? 'yml' : 'xml'));
         }
-        if (strpos($xml, '<question type="stack">') !== false || !$useyaml) {
-            $xmldata = new SimpleXMLElement($xml);
-        } else {
-            $xmldata = self::yamlstring_to_xml($xml);
-        }
+        $xmldata = new SimpleXMLElement($xml);
         $plaindata = self::xml_to_array($xmldata);
         $diff = self::obj_diff(self::$defaults['question'], $plaindata['question']);
         if (!empty($plaindata['question']['input'])) {

--- a/classes/yaml_converter.php
+++ b/classes/yaml_converter.php
@@ -80,7 +80,7 @@ class yaml_converter {
         if ($defaults) {
             self::$defaults = $defaults;
         } else {
-            self::$defaults = self::load_defaults(__DIR__ . '/../questiondefaults.yml', true);
+            self::$defaults = self::load_defaults(__DIR__ . '/../' . cli_helper::DEFAULTS_FILE . ($useyaml ? 'yml' : 'xml'));
         }
         if ($useyaml) {
             $xmldata = self::yamlstring_to_xml($data);
@@ -764,12 +764,8 @@ class yaml_converter {
         } else {
             $xmlstring = self::yaml_to_xmlstring($diff);
             $dom = new \DOMDocument();
-
-            // Initial block (must before load xml string)
             $dom->preserveWhiteSpace = false;
             $dom->formatOutput = true;
-            // End initial block
-
             $dom->loadXML($xmlstring);
             return $dom->saveXML();
         }

--- a/classes/yaml_converter.php
+++ b/classes/yaml_converter.php
@@ -504,8 +504,13 @@ class yaml_converter {
      */
     public static function yaml_to_xml($yaml) {
         $xml = new SimpleXMLElement("<?xml version='1.0' encoding='UTF-8'?><quiz></quiz>");
+        if (!isset($yaml['question'])) {
+            $question = $xml->addChild('question');
+            self::array_to_xml($yaml, $question);
+        } else {
+            self::array_to_xml($yaml, $xml);
+        }
 
-        self::array_to_xml($yaml, $xml);
         // Name is a special case. Has text tag but no format.
         $name = isset($xml->question->name) ? (string) $xml->question->name : self::get_default('question', 'name');
         $xml->question->name = new SimpleXMLElement('<root></root>');

--- a/classes/yaml_converter.php
+++ b/classes/yaml_converter.php
@@ -83,7 +83,7 @@ class yaml_converter {
             self::$defaults = self::load_defaults(__DIR__ . '/../questiondefaults.yml');
         }
         try {
-            $xmldata = self::yaml_to_xml($yaml);
+            $xmldata = self::yamlstring_to_xml($yaml);
         } catch (\Exception $e) {
             throw new \Exception("The provided file does not contain valid YAML");
         }
@@ -442,12 +442,48 @@ class yaml_converter {
      * @return SimpleXMLElement The resulting XML object.
      * @throws \stack_exception If the YAML string is invalid.
      */
-    public static function yaml_to_xml($yamlstring) {
+    public static function yamlstring_to_xml($yamlstring) {
         self::require_yaml();
         $yaml = Yaml::parse($yamlstring);
         if (!$yaml) {
             throw new \stack_exception("The provided file does not contain valid YAML or XML.");
         }
+        $xml = self::yaml_to_xml($yaml);
+        return $xml;
+    }
+
+    /**
+     * Converts YAML to an XML string.
+     *
+     * @param array $yaml The YAML to convert.
+     * @return string The resulting XML string.
+     */
+    public static function yaml_to_xmlstring($yaml) {
+        $xml = self::yaml_to_xml($yaml);
+        return $xml->asXML();
+    }
+
+    /**
+     * Converts YAML string to an XML string.
+     *
+     * @param string $yamlstring The YAML string to convert.
+     * @return string The resulting XML string.
+     */
+    public static function xmlstring_to_yamlstring($xmlstring) {
+        $xml = new SimpleXMLElement($xmlstring);
+        $yaml = self::xml_to_array($xml);
+        self::require_yaml();
+        $yaml = Yaml::dump($yaml, 10, 2, Yaml::DUMP_MULTI_LINE_LITERAL_BLOCK | Yaml::DUMP_COMPACT_NESTED_MAPPING);
+        return $yaml;
+    }
+
+    /**
+     * Converts YAML to a SimpleXMLElement object.
+     *
+     * @param string $yaml The YAML to convert.
+     * @return SimpleXMLElement $xml The resulting XML.
+     */
+    public static function yaml_to_xml($yaml) {
         $xml = new SimpleXMLElement("<?xml version='1.0' encoding='UTF-8'?><quiz></quiz>");
         $question = $xml->addChild('question');
         $question->addAttribute('type', 'stack');
@@ -477,7 +513,7 @@ class yaml_converter {
                 // Convert basic YAML field to node with text and format fields.
                 if ($key !== 'name') {
                     // Name is used in multiple places and sometimes has text property and sometimes not.
-                    // Handled in yaml_to_xml().
+                    // Handled in yamlstring_to_xml().
                     $subnode = $xml->addChild($key);
                     $subvalue = ['text' => $value];
                     if (isset($data[$key . 'format'])) {
@@ -516,9 +552,11 @@ class yaml_converter {
      * Converts a SimpleXMLElement object to an array for conversion to YAML.
      *
      * @param SimpleXMLElement The resulting XML object.
+     * @param array Previous output.
+     * @param boolean Are we converting a default file. We need to make it flatter.
      * @return array The resulting array.
      */
-    public static function xml_to_array($xmldata, &$output = []) {
+    public static function xml_to_array($xmldata, &$output = [], $isdefault = false) {
         foreach ($xmldata as $key => $value) {
             if (in_array($key, self::TEXTFIELDS)) {
                 if (isset($value->text)) {
@@ -530,14 +568,14 @@ class yaml_converter {
                     $output[$key . 'format'] = (string) $xmldata->{$key}['format'];
                 }
             } else if ($value instanceof SimpleXMLElement && $value->count()) {
-                if (in_array($key, self::ARRAYFIELDS)) {
+                if (in_array($key, self::ARRAYFIELDS) && !$isdefault) {
                     $output[$key][] = self::xml_to_array($value);
                 } else {
                     $output[$key] = [];
                     self::xml_to_array($value, $output[$key]);
                 }
             } else {
-                if (in_array($key, self::ARRAYFIELDS)) {
+                if (in_array($key, self::ARRAYFIELDS) && !$isdefault) {
                     $output[$key][] = (string) $value;
                 } else {
                     $output[$key] = (string) $value;
@@ -550,11 +588,18 @@ class yaml_converter {
     /**
      * Load a parse file with default values for questions.
      * @param string filepath
+     * @param boolean $isyaml Is default file YAML? (Rather than XML?).
      * @return array YAML
      */
-    public static function load_defaults($defaultfile) {
-        self::require_yaml();
-        $defaults = Yaml::parseFile($defaultfile);
+    public static function load_defaults($defaultfile, $isyaml = true) {
+        if ($isyaml) {
+            self::require_yaml();
+            $defaults = Yaml::parseFile($defaultfile);
+        } else {
+            $xml = file_get_contents($defaultfile);
+            $defaults = new SimpleXMLElement($xml);
+            $defaults = self::xml_to_array($defaults, isdefault: true);
+        }
         if (!$defaults) {
             echo "\nUnable to access or parse default file: {$defaultfile}\nAborting.\n";
             self::call_exit();
@@ -577,18 +622,19 @@ class yaml_converter {
      * Detects differences between the provided XML or YAML and the default question structure.
      *
      * @param string $xml The XML or YAML string to compare.
-     * @return string The differences in YAML format.
+     * @param boolean $useyaml Return YAML? (Rather than XML?).
+     * @return string The differences.
      */
-    public static function detect_differences($xml, $defaults) {
+    public static function detect_differences($xml, $defaults, $useyaml = true) {
         if ($defaults) {
             self::$defaults = $defaults;
         } else {
             self::$defaults = self::load_defaults(__DIR__ . '/../questiondefaults.yml');
         }
-        if (strpos($xml, '<question type="stack">') !== false) {
+        if (strpos($xml, '<question type="stack">') !== false || !$useyaml) {
             $xmldata = new SimpleXMLElement($xml);
         } else {
-            $xmldata = self::yaml_to_xml($xml);
+            $xmldata = self::yamlstring_to_xml($xml);
         }
         $plaindata = self::xml_to_array($xmldata);
         $diff = self::obj_diff(self::$defaults['question'], $plaindata['question']);
@@ -685,9 +731,22 @@ class yaml_converter {
             }
             $diff['qtest'] = $difftests;
         }
-        self::require_yaml();
-        $yaml = Yaml::dump($diff, 10, 2, Yaml::DUMP_MULTI_LINE_LITERAL_BLOCK | Yaml::DUMP_COMPACT_NESTED_MAPPING);
-        return $yaml;
+        if ($useyaml) {
+            self::require_yaml();
+            $yaml = Yaml::dump($diff, 10, 2, Yaml::DUMP_MULTI_LINE_LITERAL_BLOCK | Yaml::DUMP_COMPACT_NESTED_MAPPING);
+            return $yaml;
+        } else {
+            $xmlstring = self::yaml_to_xmlstring($diff);
+            $dom = new \DOMDocument();
+
+            // Initial block (must before load xml string)
+            $dom->preserveWhiteSpace = false;
+            $dom->formatOutput = true;
+            // End initial block
+
+            $dom->loadXML($xmlstring);
+            return $dom->saveXML();
+        }
     }
 
     /**

--- a/cli/config_sample.txt
+++ b/cli/config_sample.txt
@@ -77,3 +77,8 @@ $usefragments = false;
 // Be careful with truncation of category names - duplicate truncated categories with the same parent category will be merged.
 $maxcatlength = 200;
 $maxqlength = 230;
+
+// At various points Gitsync will show information and then wait for a response. This information is important and worth reading.
+// The default prompt is 'Abort?' to avoid fast-fingering 'y' to continue. You can swap the question to 'Continue?'
+// with this flag.
+$usecontinue = false;

--- a/cli/config_sample.txt
+++ b/cli/config_sample.txt
@@ -66,8 +66,11 @@ $usegit = true;
 // saved in the manifest file during repo creation will be used on import/export.
 $ignorecat = null;
 
-// Should questions be exported as YAML difference files?
+// Should questions be exported as YAMLfiles?
 $useyaml = false;
+
+// Should questions be exported as difference files?
+$usefragments = false;
 
 // Max character length of category folder names and question file names.
 // You may need to reduce these on Windows so that overall filepath for questions does not excede the system limit.

--- a/cli/createrepo.php
+++ b/cli/createrepo.php
@@ -175,9 +175,17 @@ $options = [
     [
         'longopt' => 'useyaml',
         'shortopt' => 'y',
-        'description' => 'Export questions as YAML difference file?',
+        'description' => 'Export questions as YAML?',
         'default' => $useyaml,
         'variable' => 'useyaml',
+        'valuerequired' => true,
+    ],
+    [
+        'longopt' => 'usefragments',
+        'shortopt' => 'b',
+        'description' => 'Export questions as difference files?',
+        'default' => $usefragments,
+        'variable' => 'usefragments',
         'valuerequired' => true,
     ],
     [

--- a/cli/createwholecourserepo.php
+++ b/cli/createwholecourserepo.php
@@ -155,9 +155,17 @@ $options = [
     [
         'longopt' => 'useyaml',
         'shortopt' => 'y',
-        'description' => 'Export questions as YAML difference file?',
+        'description' => 'Export questions as YAML?',
         'default' => $useyaml,
         'variable' => 'useyaml',
+        'valuerequired' => true,
+    ],
+    [
+        'longopt' => 'usefragments',
+        'shortopt' => 'b',
+        'description' => 'Export questions as difference files?',
+        'default' => $usefragments,
+        'variable' => 'usefragments',
         'valuerequired' => true,
     ],
 ];

--- a/cli/exportrepofrommoodle.php
+++ b/cli/exportrepofrommoodle.php
@@ -125,9 +125,17 @@ $options = [
     [
         'longopt' => 'useyaml',
         'shortopt' => 'y',
-        'description' => 'Export questions as YAML difference file?',
+        'description' => 'Export questions as YAML?',
         'default' => $useyaml,
         'variable' => 'useyaml',
+        'valuerequired' => true,
+    ],
+    [
+        'longopt' => 'usefragments',
+        'shortopt' => 'b',
+        'description' => 'Export questions as difference files?',
+        'default' => $usefragments,
+        'variable' => 'usefragments',
         'valuerequired' => true,
     ],
     [

--- a/cli/exportwholecoursefrommoodle.php
+++ b/cli/exportwholecoursefrommoodle.php
@@ -117,9 +117,17 @@ $options = [
     [
         'longopt' => 'useyaml',
         'shortopt' => 'y',
-        'description' => 'Export questions as YAML difference file?',
+        'description' => 'Export questions as YAML?',
         'default' => $useyaml,
         'variable' => 'useyaml',
+        'valuerequired' => true,
+    ],
+    [
+        'longopt' => 'usefragments',
+        'shortopt' => 'b',
+        'description' => 'Export questions as difference files?',
+        'default' => $usefragments,
+        'variable' => 'usefragments',
         'valuerequired' => true,
     ],
 ];

--- a/cli/importquiztomoodle.php
+++ b/cli/importquiztomoodle.php
@@ -150,9 +150,17 @@ $options = [
     [
         'longopt' => 'useyaml',
         'shortopt' => 'y',
-        'description' => 'Export questions as YAML difference file?',
+        'description' => 'Export questions as YAML?',
         'default' => $useyaml,
         'variable' => 'useyaml',
+        'valuerequired' => true,
+    ],
+    [
+        'longopt' => 'usefragments',
+        'shortopt' => 'b',
+        'description' => 'Export questions as difference files?',
+        'default' => $usefragments,
+        'variable' => 'usefragments',
         'valuerequired' => true,
     ],
     [

--- a/cli/importrepotomoodle.php
+++ b/cli/importrepotomoodle.php
@@ -165,9 +165,17 @@ $options = [
     [
         'longopt' => 'useyaml',
         'shortopt' => 'y',
-        'description' => 'Export questions as YAML difference file?',
+        'description' => 'Export questions as YAML?',
         'default' => $useyaml,
         'variable' => 'useyaml',
+        'valuerequired' => true,
+    ],
+    [
+        'longopt' => 'usefragments',
+        'shortopt' => 'b',
+        'description' => 'Export questions as difference files?',
+        'default' => $usefragments,
+        'variable' => 'usefragments',
         'valuerequired' => true,
     ],
     [

--- a/cli/importwholecoursetomoodle.php
+++ b/cli/importwholecoursetomoodle.php
@@ -168,9 +168,17 @@ $options = [
     [
         'longopt' => 'useyaml',
         'shortopt' => 'y',
-        'description' => 'Export questions as YAML difference file?',
+        'description' => 'Export questions as YAML?',
         'default' => $useyaml,
         'variable' => 'useyaml',
+        'valuerequired' => true,
+    ],
+    [
+        'longopt' => 'usefragments',
+        'shortopt' => 'b',
+        'description' => 'Export questions as difference files?',
+        'default' => $usefragments,
+        'variable' => 'usefragments',
         'valuerequired' => true,
     ],
     [

--- a/doc/createrepo.md
+++ b/doc/createrepo.md
@@ -28,7 +28,8 @@
 |h|help|
 |u|usegit|Is the repo controlled using Git?
 |x|ignorecat|Regex of categories to ignore - add an extra leading / for Windows.
-|y|useyaml|Export questions as YAML difference file?|
+|y|useyaml|Export questions as YAML?|
+|b|usefragments|Export questions as difference files?|
 
 For Moodle 5+, there are no longer course, course category or system context question banks. Questions are contained
 in module level question banks. This makes things simpler. Where command line parameters for

--- a/doc/createwholecourserepo.md
+++ b/doc/createwholecourserepo.md
@@ -23,7 +23,8 @@
 |h|help|
 |u|usegit|Is the repo controlled using Git?
 |x|ignorecat|Regex of categories to ignore - add an extra leading / for Windows.
-|y|useyaml|Export questions as YAML difference file?|
+|y|useyaml|Export questions as YAML?|
+|b|usefragments|Export questions as difference files?|
 
 This is very similar to [`createrepo.php`](createrepo.md) but normally Gitsync retrieves questions within a Moodle context, returning all or a subselection of question categories with the repo directory structure matching the category structure in Moodle. Courses and quizzes are in separate contexts, however. Use `createwholecourserepo.php` to keep quizzes with their parent course in a single repo.
 

--- a/doc/exportrepofrommoodle.md
+++ b/doc/exportrepofrommoodle.md
@@ -21,7 +21,8 @@
 |h|help|
 |u|usegit|Is the repo controlled using Git?
 |x|ignorecat|Regex of categories to ignore - add an extra leading / for Windows.
-|y|useyaml|Export questions as YAML difference file?|
+|y|useyaml|Export questions as YAML?|
+|b|usefragments|Export questions as difference files?|
 
 Example:
 

--- a/doc/exportwholecoursefrommoodle.md
+++ b/doc/exportwholecoursefrommoodle.md
@@ -20,7 +20,8 @@
 |h|help|
 |u|usegit|Is the repo controlled using Git?
 |x|ignorecat|Regex of categories to ignore - add an extra leading / for Windows.
-|y|useyaml|Export questions as YAML difference file?|
+|y|useyaml|Export questions as YAML?|
+|b|usefragments|Export questions as difference files?|
 
 Examples:
 

--- a/doc/importquiztomoodle.md
+++ b/doc/importquiztomoodle.md
@@ -33,7 +33,8 @@ Commit this update.
 |u|usegit|Is the repo controlled using Git?
 |x|ignorecat|Regex of categories to ignore - add an extra leading / for Windows.
 |z|forceimport|Force import of all questions, even if current commit previously imported.
-|y|useyaml|Export questions as YAML difference file?|
+|y|useyaml|Export questions as YAML?|
+|b|usefragments|Export questions as difference files?|
 
 Examples:
 

--- a/doc/importrepotomoodle.md
+++ b/doc/importrepotomoodle.md
@@ -38,7 +38,8 @@ Commit this update.
 |u|usegit|Is the repo controlled using Git?
 |x|ignorecat|Regex of categories to ignore - add an extra leading / for Windows.
 |z|forceimport|Force import of all questions, even if current commit previously imported.
-|y|useyaml|Export questions as YAML difference file?|
+|y|useyaml|Export questions as YAML?|
+|b|usefragments|Export questions as difference files?|
 
 ## Scenario 1: Importing questions into Moodle from an existing repo
 

--- a/doc/importwholecoursetomoodle.md
+++ b/doc/importwholecoursetomoodle.md
@@ -33,7 +33,8 @@ Commit this update.
 |u|usegit|Is the repo controlled using Git?
 |x|ignorecat|Regex of categories to ignore - add an extra leading / for Windows.
 |z|forceimport|Force import of all questions, even if current commit previously imported.
-|y|useyaml|Export questions as YAML difference file?|
+|y|useyaml|Export questions as YAML?|
+|b|usefragments|Export questions as difference files?|
 
 Examples:
 

--- a/doc/usefragments.md
+++ b/doc/usefragments.md
@@ -1,0 +1,67 @@
+# Storing questions as difference fragments
+
+Even simple STACK questions contain a great deal of XML, much of which is likely to be the same for all your questions. 
+
+By setting `usefragments` to true either in your config file (`usefragments = true;`) or for individual script runs (`--usefragments "true"`), you can store STACK questions in your repo as difference representations. When exporting to the repo, Gitsync downloads STACK questions as normal and then compares them with a defaults file. Fields that match the default (and are not part of the minimum represenations) are removed and then what's left is stored in the repo. Non-STACK questions will be left as they are. (You can combine this with `useyaml` to get [YAML fragments](useyaml.md) which are much more readable.)
+
+Gitsync will select a defaults file on the following basis:
+  - If you supply a filename as a script argument (`--defaultfile` or `-o`), Gitsync will look for it in the repo directory.
+  - Otherwise, if there is a default file recorded in the manifest file from manifest creation, Gitsync will look for it in the repo directory.
+  - Failing that, Gitsync will look for a `questiondefault.xml` in the repo directory.
+  - As a last resort, Gitsync will use [it's own defaults file](../questiondefaults.xml).
+
+Certain important fields are always included in the XML representation even if they match the default. The example below is for a default question with a single input, PRT and node but fields will be shown for every input, prt and node in a more complex question.
+
+```
+<?xml version="1.0" encoding="UTF-8"?>
+<quiz>
+  <question type="stack">
+    <name>
+      <text>Default</text>
+    </name>
+    <questionsimplify>1</questionsimplify>
+    <input>
+      <name>ans1</name>
+      <type>algebraic</type>
+      <tans>ta1</tans>
+      <forbidfloat>1</forbidfloat>
+      <requirelowestterms>0</requirelowestterms>
+      <checkanswertype>0</checkanswertype>
+      <mustverify>1</mustverify>
+      <showvalidation>1</showvalidation>
+    </input>
+    <prt>
+      <name>prt1</name>
+      <autosimplify>1</autosimplify>
+      <feedbackstyle>1</feedbackstyle>
+      <node>
+        <name>0</name>
+        <answertest>AlgEquiv</answertest>
+        <sans>ans1</sans>
+        <tans>ta1</tans>
+        <quiet>0</quiet>
+      </node>
+    </prt>
+  </question>
+</quiz>
+```
+
+Additionally you can set your default file so that the answer tests for your questions are stored
+in a summary format:
+```
+ATanswertest(sans,tans,testoptions)
+```
+Default file example:
+```
+  <answertest>ATAlgEquiv(ans1,ta1)</answertest>
+  <sans></sans>
+  <tans></tans>
+  <testoptions></testoptions>
+  # sans, tans, testoptions will not be used but need to be here for diff compatibility
+  # with questions which have them rather than the summary answertest.
+```
+
+When importing to Moodle, Gitsync adds all the missing fields to the XML representation, creates a temporary XML file in the repo directory and then uploads this to Moodle. The defaults file is selected in the same way as for export so you can use different defaults if required. If you haven't set Gitsync to use fragments but your XML is incomplete, STACK has built in defaults and will attempt to fill in the gaps - you will need to export your questions from Moodle to see the results in your repo.
+
+Obviously, using different defaults for import and export should be handled with care to avoid information loss! It makes most sense for altering site-specific settings that will be the same for every question e.g. decimal separator. Normally Gitsync skips importing questions that have not changed in the repo since the last import so if you want to update them using different defaults you will need to use `-z` to force import of questions that have not changed themselves.
+

--- a/doc/useyaml.md
+++ b/doc/useyaml.md
@@ -7,7 +7,9 @@ Notes:
 1. _If you wish to store questions in YAML format you will need to install Symfony YAML on the local PHP setup (not on Moodle). This can be done via composer._
 2. _If you want to switch between using YAML and XML, create a new repo. Switching an existing repo will cause problems with filename extensions._
 
-By setting `useyaml` to true either in your config file (`useyaml = true;`) or for individual script runs (`--useyaml "true"`), you can store STACK questions in your repo as YAML difference representations. When exporting to the repo, Gitsync downloads STACK questions as normal, converts them to YAML and then compares them with a defaults file. Fields that match the default (and are not part of the minimum represenations) are removed and then what's left is stored in the repo. Non-STACK questions will be left as XML.
+By setting `useyaml` to true either in your config file (`useyaml = true;`) or for individual script runs (`--useyaml "true"`), you can store STACK questions in your repo as YAML difference representations. When exporting to the repo, Gitsync downloads STACK questions as normal and then converts them to YAML. Non-STACK questions will be left as XML.
+
+If you also set `usefragments` to true either in your config file (`usefragments = true;`) or for individual script runs (`--usefragments "true"`), Gitsync then compares them with a defaults file. Fields that match the default (and are not part of the minimum represenations) are removed and then what's left is stored in the repo.
 
 Gitsync will select a defaults file on the following basis:
   - If you supply a filename as a script argument (`--defaultfile` or `-o`), Gitsync will look for it in the repo directory.
@@ -72,7 +74,7 @@ Default file example:
   testoptions:
 ```
 
-When importing to Moodle, Gitsync adds all the missing fields to the YAML representation from the defaults file, converts it to XML, creates a temporary XML file in the repo directory and then uploads this to Moodle. The defaults file is selected in the same way as for export so you can use different defaults if required.
+When importing to Moodle, Gitsync adds all the missing fields to the YAML representation from the defaults file, converts it to XML, creates a temporary XML file in the repo directory and then uploads this to Moodle. The defaults file is selected in the same way as for export so you can use different defaults if required. If you haven't set Gitsync to use fragments but your YAML is incomplete, STACK has built in defaults and will attempt to fill in the gaps - you will need to export your questions from Moodle to see the results in your repo.
 
 Obviously, using different defaults for import and export should be handled with care to avoid information loss! It makes most sense for altering site-specific settings that will be the same for every question e.g. decimal separator. Normally Gitsync skips importing questions that have not changed in the repo since the last import so if you want to update them using different defaults you will need to use `-z` to force import of questions that have not changed themselves.
 

--- a/doc/usinggit.md
+++ b/doc/usinggit.md
@@ -9,6 +9,7 @@ It is recommended you at least skim the whole of this document before attempting
 For detailed information on what happens at each stage of the process, see [Process Details](processdetails.md).
 
 To store your questions as YAML rather than XML, see [Using YAML](useyaml.md).
+To store your questions as difference files or 'fragments', see [Using fragments](usefragments.md).
 
 If you want to track a course and all its quizzes in a single repo, you will need to use different scripts that function in a similar way to the single context scripts:
 - Creating a repo - [createwholecourserepo.php](createwholecourserepo.md)

--- a/questiondefaults.xml
+++ b/questiondefaults.xml
@@ -16,10 +16,10 @@
     <stackversion>2025042500</stackversion>
     <questionvariables>ta1:1;</questionvariables>
     <specificfeedback format="html">
-      <text><![CDATA[<p>[[feedback:prt1]]</p>]]></text>
+      <text><![CDATA[[[feedback:prt1]]]]></text>
     </specificfeedback>
     <questionnote format="html">
-      <text><![CDATA[<p>{@ta1@}</p>]]></text>
+      <text><![CDATA[{@ta1@}]]></text>
     </questionnote>
     <questiondescription format="html">
       <text></text>
@@ -28,13 +28,13 @@
     <assumepositive>0</assumepositive>
     <assumereal>0</assumereal>
     <prtcorrect format="html">
-      <text><![CDATA[<p><i class="fa fa-check"></i> Correct answer, well done.</p>]]></text>
+      <text><![CDATA[<span style="font-size: 1.5em; color:green;"><i class="fa fa-check"></i></span> Correct answer, well done.]]></text>
     </prtcorrect>
     <prtpartiallycorrect format="html">
-      <text><![CDATA[<p><i class="fa fa-adjust"></i> Your answer is partially correct.</p>]]></text>
+      <text><![CDATA[<span style="font-size: 1.5em; color:orange;"><i class="fa fa-adjust"></i></span> Your answer is partially correct.]]></text>
     </prtpartiallycorrect>
-      <prtincorrect format="html">
-    <text><![CDATA[<p><i class="fa fa-times"></i> Incorrect answer.</p>]]></text>
+    <prtincorrect format="html">
+      <text><![CDATA[<span style="font-size: 1.5em; color:red;"><i class="fa fa-times"></i></span> Incorrect answer.]]></text>
     </prtincorrect>
     <decimals>.</decimals>
     <scientificnotation>*10</scientificnotation>
@@ -72,7 +72,9 @@
     <value>1.0000000</value>
     <autosimplify>1</autosimplify>
     <feedbackstyle>1</feedbackstyle>
-    <feedbackvariables></feedbackvariables>
+    <feedbackvariables>
+      <text></text>
+    </feedbackvariables>
   </prt>
 
   <node>

--- a/questiondefaults.xml
+++ b/questiondefaults.xml
@@ -1,0 +1,120 @@
+<?xml version="1.0" encoding="UTF-8"?>
+<defaults>
+  <question>
+    <name>
+      <text>Default</text></name>
+    <questiontext format="html">
+      <text><![CDATA[<p>Default question</p><p>[[input:ans1]] [[validation:ans1]]</p>]]></text>
+    </questiontext>
+    <generalfeedback format="html">
+      <text></text>
+    </generalfeedback>
+    <defaultgrade>1</defaultgrade>
+    <penalty>0.1</penalty>
+    <hidden>0</hidden>
+    <idnumber></idnumber>
+    <stackversion>2025042500</stackversion>
+    <questionvariables>ta1:1;</questionvariables>
+    <specificfeedback format="html">
+      <text><![CDATA[<p>[[feedback:prt1]]</p>]]></text>
+    </specificfeedback>
+    <questionnote format="html">
+      <text><![CDATA[<p>{@ta1@}</p>]]></text>
+    </questionnote>
+    <questiondescription format="html">
+      <text></text>
+    </questiondescription>
+    <questionsimplify>1</questionsimplify>
+    <assumepositive>0</assumepositive>
+    <assumereal>0</assumereal>
+    <prtcorrect format="html">
+      <text><![CDATA[<p><i class="fa fa-check"></i> Correct answer, well done.</p>]]></text>
+    </prtcorrect>
+    <prtpartiallycorrect format="html">
+      <text><![CDATA[<p><i class="fa fa-adjust"></i> Your answer is partially correct.</p>]]></text>
+    </prtpartiallycorrect>
+      <prtincorrect format="html">
+    <text><![CDATA[<p><i class="fa fa-times"></i> Incorrect answer.</p>]]></text>
+    </prtincorrect>
+    <decimals>.</decimals>
+    <scientificnotation>*10</scientificnotation>
+    <multiplicationsign>dot</multiplicationsign>
+    <sqrtsign>1</sqrtsign>
+    <complexno>i</complexno>
+    <inversetrig>cos-1</inversetrig>
+    <logicsymbol>lang</logicsymbol>
+    <matrixparens>[</matrixparens>
+    <isbroken>0</isbroken>
+    <variantsselectionseed></variantsselectionseed>
+  </question>
+
+  <input>
+    <name>ans1</name>
+    <type>algebraic</type>
+    <tans>ta1</tans>
+    <boxsize>15</boxsize>
+    <strictsyntax>1</strictsyntax>
+    <insertstars>0</insertstars>
+    <syntaxhint></syntaxhint>
+    <syntaxattribute>0</syntaxattribute>
+    <forbidwords></forbidwords>
+    <allowwords></allowwords>
+    <forbidfloat>1</forbidfloat>
+    <requirelowestterms>0</requirelowestterms>
+    <checkanswertype>0</checkanswertype>
+    <mustverify>1</mustverify>
+    <showvalidation>1</showvalidation>
+    <options></options>
+  </input>
+
+  <prt>
+    <name>prt1</name>
+    <value>1.0000000</value>
+    <autosimplify>1</autosimplify>
+    <feedbackstyle>1</feedbackstyle>
+    <feedbackvariables></feedbackvariables>
+  </prt>
+
+  <node>
+    <name>0</name>
+    <description></description>
+    <answertest>AlgEquiv</answertest>
+    <sans>ans1</sans>
+    <tans>ta1</tans>
+    <testoptions></testoptions>
+    <quiet>0</quiet>
+    <truescoremode>=</truescoremode>
+    <truescore>1.0000000</truescore>
+    <truepenalty></truepenalty>
+    <truenextnode>-1</truenextnode>
+    <trueanswernote>prt1-1-T</trueanswernote>
+    <truefeedback format="html">
+      <text></text>
+    </truefeedback>
+    <falsescoremode>=</falsescoremode>
+    <falsescore>0.0000000</falsescore>
+    <falsepenalty></falsepenalty>
+    <falsenextnode>-1</falsenextnode>
+    <falseanswernote>prt1-1-F</falseanswernote>
+    <falsefeedback format="html">
+      <text></text>
+    </falsefeedback>
+  </node>
+
+  <qtest>
+    <testcase>1</testcase>
+    <description></description>
+  </qtest>
+
+  <testinput>
+    <name>ans1</name>
+    <value>ta1</value>
+  </testinput>
+
+  <expected>
+    <name>prt1</name>
+    <expectedscore></expectedscore>
+    <expectedpenalty></expectedpenalty>
+    <expectedanswernote>1-0-T</expectedanswernote>
+  </expected>
+</defaults>

--- a/questiondefaults.xml
+++ b/questiondefaults.xml
@@ -13,7 +13,9 @@
     <penalty>0.1</penalty>
     <hidden>0</hidden>
     <idnumber></idnumber>
-    <stackversion>2025042500</stackversion>
+    <stackversion>
+      <text>2025102200</text>
+    </stackversion>
     <questionvariables>ta1:1;</questionvariables>
     <specificfeedback format="html">
       <text><![CDATA[[[feedback:prt1]]]]></text>

--- a/questiondefaults.yml
+++ b/questiondefaults.yml
@@ -11,20 +11,20 @@ question:
   idnumber: ''
   stackversion: '2025042500'
   questionvariables: 'ta1:1;'
-  specificfeedback: '<p>[[feedback:prt1]]</p>'
+  specificfeedback: '[[feedback:prt1]]'
   specificfeedbackformat: html
-  questionnote: '<p>{@ta1@}</p>'
+  questionnote: '{@ta1@}'
   questionnoteformat: html
   questiondescription: ''
   questiondescriptionformat: html
   questionsimplify: '1'
   assumepositive: '0'
   assumereal: '0'
-  prtcorrect: '<p><i class="fa fa-check"></i> Correct answer, well done.</p>'
+  prtcorrect: '<span style="font-size: 1.5em; color:green;"><i class="fa fa-check"></i></span> Correct answer, well done.'
   prtcorrectformat: html
-  prtpartiallycorrect: <p><i class="fa fa-adjust"></i> Your answer is partially correct.</p>
+  prtpartiallycorrect: '<span style="font-size: 1.5em; color:orange;"><i class="fa fa-adjust"></i></span> Your answer is partially correct.'
   prtpartiallycorrectformat: html
-  prtincorrect: <p><i class="fa fa-times"></i> Incorrect answer.</p>
+  prtincorrect: '<span style="font-size: 1.5em; color:red;"><i class="fa fa-times"></i></span> Incorrect answer.'
   prtincorrectformat: html
   decimals: .
   scientificnotation: '*10'

--- a/questiondefaults.yml
+++ b/questiondefaults.yml
@@ -9,7 +9,7 @@ question:
   penalty: '0.1'
   hidden: '0'
   idnumber: ''
-  stackversion: '2025042500'
+  stackversion: '2025102200'
   questionvariables: 'ta1:1;'
   specificfeedback: '[[feedback:prt1]]'
   specificfeedbackformat: html

--- a/tests/create_repo_test.php
+++ b/tests/create_repo_test.php
@@ -79,6 +79,7 @@ final class create_repo_test extends advanced_testcase {
             'ignorecat' => null,
             'usegit' => false,
             'useyaml' => false,
+            'usefragments' => false,
         ];
         $this->clihelper = $this->getMockBuilder(\qbank_gitsync\cli_helper::class)->onlyMethods([
             'get_arguments', 'check_context',

--- a/tests/export_repo_test.php
+++ b/tests/export_repo_test.php
@@ -100,6 +100,7 @@ final class export_repo_test extends advanced_testcase {
             'ignorecat' => null,
             'usegit' => true,
             'useyaml' => false,
+            'usefragments' => false,
         ];
         $this->clihelper = $this->getMockBuilder(\qbank_gitsync\cli_helper::class)->onlyMethods([
             'get_arguments', 'check_context',

--- a/tests/export_trait_test.php
+++ b/tests/export_trait_test.php
@@ -75,6 +75,7 @@ final class export_trait_test extends advanced_testcase {
             'ignorecat' => null,
             'usegit' => true,
             'useyaml' => false,
+            'usefragments' => false,
         ];
         $this->clihelper = $this->getMockBuilder(\qbank_gitsync\cli_helper::class)->onlyMethods([
             'get_arguments', 'check_context',

--- a/tests/fixtures/fullquestion.xml
+++ b/tests/fixtures/fullquestion.xml
@@ -6,7 +6,7 @@
     </name>
     <questiontext format="html">
       <text><![CDATA[<p>Question</p><p>[[input:ans1]] [[validation:ans1]]</p>
-<p>[[input:ans2]] [[validation:ans2]]</p>]]></text>
+    <p>[[input:ans2]] [[validation:ans2]]</p>]]></text>
     </questiontext>
     <generalfeedback format="html">
       <text/>
@@ -22,10 +22,10 @@
       <text>ta1:1;ta2:2;</text>
     </questionvariables>
     <specificfeedback format="html">
-      <text><![CDATA[<p>[[feedback:prt1]]</p>]]></text>
+      <text><![CDATA[[[feedback:prt1]]]]></text>
     </specificfeedback>
     <questionnote format="html">
-      <text><![CDATA[<p>{@ta1@}</p>]]></text>
+      <text><![CDATA[{@ta1@}]]></text>
     </questionnote>
     <questiondescription format="html">
       <text/>
@@ -37,10 +37,10 @@
       <text><![CDATA[<p><i class="fa fa-check"></i> Correct answer*, well done.</p>]]></text>
     </prtcorrect>
     <prtpartiallycorrect format="html">
-      <text><![CDATA[<p><i class="fa fa-adjust"></i> Your answer is partially correct.</p>]]></text>
+      <text><![CDATA[<span style="font-size: 1.5em; color:orange;"><i class="fa fa-adjust"></i></span> Your answer is partially correct.]]></text>
     </prtpartiallycorrect>
     <prtincorrect format="html">
-      <text><![CDATA[<p><i class="fa fa-times"></i> Incorrect answer.</p>]]></text>
+      <text><![CDATA[<span style="font-size: 1.5em; color:red;"><i class="fa fa-times"></i></span> Incorrect answer.]]></text>
     </prtincorrect>
     <decimals>.</decimals>
     <scientificnotation>*10</scientificnotation>

--- a/tests/fixtures/fullquestion.xml
+++ b/tests/fixtures/fullquestion.xml
@@ -1,0 +1,187 @@
+<?xml version="1.0" encoding="UTF-8"?>
+<quiz>
+  <question type="stack">
+    <name>
+      <text>Test question</text>
+    </name>
+    <questiontext format="html">
+      <text><![CDATA[<p>Question</p><p>[[input:ans1]] [[validation:ans1]]</p>
+<p>[[input:ans2]] [[validation:ans2]]</p>]]></text>
+    </questiontext>
+    <generalfeedback format="html">
+      <text/>
+    </generalfeedback>
+    <defaultgrade>1</defaultgrade>
+    <penalty>0.1</penalty>
+    <hidden>0</hidden>
+    <idnumber></idnumber>
+    <stackversion>
+      <text>2025042500</text>
+    </stackversion>
+    <questionvariables>
+      <text>ta1:1;ta2:2;</text>
+    </questionvariables>
+    <specificfeedback format="html">
+      <text><![CDATA[<p>[[feedback:prt1]]</p>]]></text>
+    </specificfeedback>
+    <questionnote format="html">
+      <text><![CDATA[<p>{@ta1@}</p>]]></text>
+    </questionnote>
+    <questiondescription format="html">
+      <text/>
+    </questiondescription>
+    <questionsimplify>1</questionsimplify>
+    <assumepositive>0</assumepositive>
+    <assumereal>0</assumereal>
+    <prtcorrect format="html">
+      <text><![CDATA[<p><i class="fa fa-check"></i> Correct answer*, well done.</p>]]></text>
+    </prtcorrect>
+    <prtpartiallycorrect format="html">
+      <text><![CDATA[<p><i class="fa fa-adjust"></i> Your answer is partially correct.</p>]]></text>
+    </prtpartiallycorrect>
+    <prtincorrect format="html">
+      <text><![CDATA[<p><i class="fa fa-times"></i> Incorrect answer.</p>]]></text>
+    </prtincorrect>
+    <decimals>.</decimals>
+    <scientificnotation>*10</scientificnotation>
+    <multiplicationsign>cross</multiplicationsign>
+    <sqrtsign>1</sqrtsign>
+    <complexno>i</complexno>
+    <inversetrig>cos-1</inversetrig>
+    <logicsymbol>lang</logicsymbol>
+    <matrixparens>[</matrixparens>
+    <isbroken>0</isbroken>
+    <variantsselectionseed></variantsselectionseed>
+    <deployedseed>1</deployedseed>
+    <deployedseed>2</deployedseed>
+    <deployedseed>3</deployedseed>
+    <input>
+      <name>ans1</name>
+      <type>algebraic</type>
+      <tans>ta1</tans>
+      <boxsize>25</boxsize>
+      <strictsyntax>1</strictsyntax>
+      <insertstars>0</insertstars>
+      <syntaxhint></syntaxhint>
+      <syntaxattribute>0</syntaxattribute>
+      <forbidwords></forbidwords>
+      <allowwords></allowwords>
+      <forbidfloat>1</forbidfloat>
+      <requirelowestterms>0</requirelowestterms>
+      <checkanswertype>0</checkanswertype>
+      <mustverify>1</mustverify>
+      <showvalidation>1</showvalidation>
+      <options></options>
+    </input>
+    <input>
+      <name>ans2</name>
+      <type>algebraic</type>
+      <tans>ta2</tans>
+      <boxsize>15</boxsize>
+      <strictsyntax>1</strictsyntax>
+      <insertstars>0</insertstars>
+      <syntaxhint></syntaxhint>
+      <syntaxattribute>0</syntaxattribute>
+      <forbidwords></forbidwords>
+      <allowwords></allowwords>
+      <forbidfloat>1</forbidfloat>
+      <requirelowestterms>0</requirelowestterms>
+      <checkanswertype>0</checkanswertype>
+      <mustverify>1</mustverify>
+      <showvalidation>1</showvalidation>
+      <options></options>
+    </input>
+    <prt>
+      <name>prt1</name>
+      <value>2</value>
+      <autosimplify>1</autosimplify>
+      <feedbackstyle>1</feedbackstyle>
+      <feedbackvariables>
+        <text/>
+      </feedbackvariables>
+      <node>
+        <name>0</name>
+        <description></description>
+        <answertest>AlgEquiv</answertest>
+        <sans>ans1</sans>
+        <tans>ta1</tans>
+        <testoptions></testoptions>
+        <quiet>1</quiet>
+        <truescoremode>=</truescoremode>
+        <truescore>1</truescore>
+        <truepenalty></truepenalty>
+        <truenextnode>-1</truenextnode>
+        <trueanswernote>prt1-1-T</trueanswernote>
+        <truefeedback format="html">
+          <text/>
+        </truefeedback>
+        <falsescoremode>=</falsescoremode>
+        <falsescore>0</falsescore>
+        <falsepenalty></falsepenalty>
+        <falsenextnode>-1</falsenextnode>
+        <falseanswernote>prt1-1-F</falseanswernote>
+        <falsefeedback format="html">
+          <text/>
+        </falsefeedback>
+      </node>
+    </prt>
+    <prt>
+      <name>prt2</name>
+      <value>1.0000001</value>
+      <autosimplify>1</autosimplify>
+      <feedbackstyle>1</feedbackstyle>
+      <feedbackvariables>
+        <text/>
+      </feedbackvariables>
+      <node>
+        <name>0</name>
+        <description></description>
+        <answertest>AlgEquiv</answertest>
+        <sans>ans2</sans>
+        <tans>ta2</tans>
+        <testoptions></testoptions>
+        <quiet>0</quiet>
+        <truescoremode>=</truescoremode>
+        <truescore>1</truescore>
+        <truepenalty></truepenalty>
+        <truenextnode>-1</truenextnode>
+        <trueanswernote>prt1-1-T</trueanswernote>
+        <truefeedback format="html">
+          <text/>
+        </truefeedback>
+        <falsescoremode>=</falsescoremode>
+        <falsescore>1</falsescore>
+        <falsepenalty></falsepenalty>
+        <falsenextnode>-1</falsenextnode>
+        <falseanswernote>prt1-1-F</falseanswernote>
+        <falsefeedback format="html">
+          <text/>
+        </falsefeedback>
+      </node>
+    </prt>
+    <qtest>
+      <testcase>1</testcase>
+      <description>A test</description>
+      <testinput>
+        <name>ans1</name>
+        <value>ta1</value>
+      </testinput>
+      <testinput>
+        <name>ans2</name>
+        <value>ta2</value>
+      </testinput>
+      <expected>
+        <name>prt1</name>
+        <expectedscore>1.0000000</expectedscore>
+        <expectedpenalty>0.0000000</expectedpenalty>
+        <expectedanswernote>1-0-T</expectedanswernote>
+      </expected>
+      <expected>
+        <name>prt2</name>
+        <expectedscore>1.0000000</expectedscore>
+        <expectedpenalty>0.0000000</expectedpenalty>
+        <expectedanswernote>2-0-T</expectedanswernote>
+      </expected>
+    </qtest>
+  </question>
+</quiz>

--- a/tests/fixtures/fullquestionsummary.yml
+++ b/tests/fixtures/fullquestionsummary.yml
@@ -11,9 +11,9 @@ hidden: 0
 idnumber:
 stackversion: 2025042500
 questionvariables: ta1:1;ta2:2;
-specificfeedback: <p>[[feedback:prt1]]</p>
+specificfeedback: '[[feedback:prt1]]'
 specificfeedbackformat: html
-questionnote: <p>{@ta1@}</p>
+questionnote: '{@ta1@}'
 questionnoteformat: html
 questiondescription:
 questiondescriptionformat: html

--- a/tests/fixtures/questiondefaultssugar.yml
+++ b/tests/fixtures/questiondefaultssugar.yml
@@ -11,20 +11,20 @@ question:
   idnumber: ''
   stackversion: '2025042500'
   questionvariables: 'ta1:1;'
-  specificfeedback: '<p>[[feedback:prt1]]</p>'
+  specificfeedback: '[[feedback:prt1]]'
   specificfeedbackformat: html
-  questionnote: '<p>{@ta1@}</p>'
+  questionnote: '{@ta1@}'
   questionnoteformat: html
   questiondescription: ''
   questiondescriptionformat: html
   questionsimplify: '1'
   assumepositive: '0'
   assumereal: '0'
-  prtcorrect: '<p><i class="fa fa-check"></i> Correct answer, well done.</p>'
+  prtcorrect: '<span style="font-size: 1.5em; color:green;"><i class="fa fa-check"></i></span> Correct answer, well done.'
   prtcorrectformat: html
-  prtpartiallycorrect: <p><i class="fa fa-adjust"></i> Your answer is partially correct.</p>
+  prtpartiallycorrect: '<span style="font-size: 1.5em; color:orange;"><i class="fa fa-adjust"></i></span> Your answer is partially correct.'
   prtpartiallycorrectformat: html
-  prtincorrect: <p><i class="fa fa-times"></i> Incorrect answer.</p>
+  prtincorrect: '<span style="font-size: 1.5em; color:red;"><i class="fa fa-times"></i></span> Incorrect answer.'
   prtincorrectformat: html
   decimals: .
   scientificnotation: '*10'

--- a/tests/fixtures/questiondefaultssugar.yml
+++ b/tests/fixtures/questiondefaultssugar.yml
@@ -9,7 +9,7 @@ question:
   penalty: '0.1'
   hidden: '0'
   idnumber: ''
-  stackversion: '2025042500'
+  stackversion: '2025102200'
   questionvariables: 'ta1:1;'
   specificfeedback: '[[feedback:prt1]]'
   specificfeedbackformat: html

--- a/tests/import_quiz_test.php
+++ b/tests/import_quiz_test.php
@@ -143,6 +143,7 @@ final class import_quiz_test extends advanced_testcase {
             'usegit' => true,
             'forceimport' => false,
             'useyaml' => false,
+            'usefragments' => false,
         ];
 
     }

--- a/tests/import_repo_test.php
+++ b/tests/import_repo_test.php
@@ -1444,7 +1444,7 @@ final class import_repo_test extends advanced_testcase {
         );
         $clihelper->processedoptions = $this->options;
         $clihelper->check_context($this->importrepo);
-        $this->expectOutputRegex('/^\nPreparing to.*import_repo.*Question subdirectory: top\n$/s');
+        $this->expectOutputRegex('/^\nPreparing to.*import_repo.*Question subdirectory: top\n.*files not fragments.\n$/s');
     }
 
     /**

--- a/tests/import_repo_test.php
+++ b/tests/import_repo_test.php
@@ -112,6 +112,7 @@ final class import_repo_test extends advanced_testcase {
             'ignorecat' => null,
             'forceimport' => false,
             'useyaml' => false,
+            'usefragments' => false,
         ];
         $this->clihelper = $this->getMockBuilder(\qbank_gitsync\cli_helper::class)->onlyMethods([
             'get_arguments',

--- a/tests/tidy_trait_test.php
+++ b/tests/tidy_trait_test.php
@@ -75,6 +75,7 @@ final class tidy_trait_test extends advanced_testcase {
             'ignorecat' => null,
             'usegit' => true,
             'useyaml' => false,
+            'usefragments' => false,
         ];
         $this->clihelper = $this->getMockBuilder(\qbank_gitsync\cli_helper::class)->onlyMethods([
             'get_arguments', 'check_context',

--- a/tests/yaml_converter_test.php
+++ b/tests/yaml_converter_test.php
@@ -256,13 +256,13 @@ final class yaml_converter_test extends \advanced_testcase {
         $this->assertEquals('1', (string) $prt2->node[0]->falsescore);
     }
 
-    public function test_yaml_to_xml(): void {
+    public function test_yamlstring_to_xml(): void {
         if (!defined('Symfony\Component\Yaml\Yaml::DUMP_COMPACT_NESTED_MAPPING')) {
             $this->markTestSkipped('Symfony YAML extension is not available.');
             return;
         }
         $yaml = file_get_contents(__DIR__ . '/fixtures/fullquestion.yml');
-        $xml = yaml_converter::yaml_to_xml($yaml);
+        $xml = yaml_converter::yamlstring_to_xml($yaml);
         $this->assertEquals('Test question', (string)$xml->question->name->text);
         $this->assertEquals(1,
             preg_match('/<p>Question<\/p><p>\[\[input:ans1\]\] \[\[validation:ans1\]\]<\/p>\n    <p>' .

--- a/tests/yaml_converter_test.php
+++ b/tests/yaml_converter_test.php
@@ -222,7 +222,6 @@ final class yaml_converter_test extends \advanced_testcase {
         $this->assertEquals('1', (string) $prt2->node[0]->falsescore);
     }
 
-
     public function test_loadxml_summary(): void {
         if (!defined('Symfony\Component\Yaml\Yaml::DUMP_COMPACT_NESTED_MAPPING')) {
             $this->markTestSkipped('Symfony YAML extension is not available.');
@@ -269,6 +268,60 @@ final class yaml_converter_test extends \advanced_testcase {
                 '\[\[input:ans2\]\] \[\[validation:ans2\]\]<\/p>/s', (string) $xml->question->questiontext->text));
         $this->assertEquals('html', (string)$xml->question->questiontext['format']);
         $this->assertEquals(false, isset($xml->question->questiontext->format));
+    }
+
+    public function test_yaml_to_xml(): void {
+        $data = [
+            'name' => 'Test',
+            'questiontext' => 'What is 2+2?',
+            'questiontextformat' => 'moodle',
+            'input' => [
+                [
+                    'name' => 'ans1',
+                    'tans' => '1',
+                ],
+                [
+                    'name' => 'ans1',
+                    'tans' => '2',
+                ],
+            ],
+            'prt' => [
+                [
+                    'name' => 'prt1',
+                    'value' => '23',
+                    'node' => [
+                        [
+                            'name' => '0',
+                            'sans' => '011',
+                            'tans' => '022',
+                        ],
+                        [
+                            'name' => '1',
+                            'sans' => '033',
+                            'tans' => '044',
+                        ],
+                    ],
+                ],
+            ],
+        ];
+        $xml = yaml_converter::yaml_to_xml($data);
+        $this->assertEquals('Test', $xml->question->name->text);
+        $this->assertEquals('stack', $xml->question['type']);
+        $this->assertEquals('What is 2+2?', $xml->question->questiontext->text);
+        $this->assertEquals('moodle', $xml->question->questiontext['format']);
+        $this->assertEquals('1', $xml->question->prt[0]->node[1]->name);
+    }
+
+    public function xmlstring_to_yamlstring(): void {
+        if (!defined('Symfony\Component\Yaml\Yaml::DUMP_COMPACT_NESTED_MAPPING')) {
+            $this->markTestSkipped('Symfony YAML extension is not available.');
+            return;
+        }
+        // Test the difference detection with a full question.
+        $xmlstring = file_get_contents(__DIR__ . '/../questiondefaults.xml');
+        $expectedyamlstring = file_get_contents(__DIR__ . '/../questiondefaults.yml');
+        $yamlstring = yaml_converter::xmlstring_to_yamlstring($xmlstring);
+        $this->assertEquals($expectedyamlstring, $yamlstring);
     }
 
     public function test_array_to_xml_inverse(): void {
@@ -319,6 +372,48 @@ final class yaml_converter_test extends \advanced_testcase {
         $this->assertEquals('044', $xml->prt[0]->node[1]->tans);
         $array = yaml_converter::xml_to_array($xml);
         $this->assertEqualsCanonicalizing($data, $array);
+    }
+
+    public function test_defaults_xml_to_array(): void {
+        $data = [
+            'name' => 'Test',
+            'questiontext' => 'What is 2+2?',
+            'questiontextformat' => 'moodle',
+            'input' => [
+                [
+                    'name' => 'ans1',
+                    'tans' => '1',
+                ],
+                [
+                    'name' => 'ans1',
+                    'tans' => '2',
+                ],
+            ],
+            'prt' => [
+                [
+                    'name' => 'prt1',
+                    'value' => '23',
+                ],
+            ],
+            'node' => [
+                        [
+                            'name' => '0',
+                            'sans' => '011',
+                            'tans' => '022',
+                        ]
+                    ],
+        ];
+        $xml = new \SimpleXMLElement('<question></question>');
+        yaml_converter::array_to_xml($data, $xml);
+        $this->assertEquals('Test', $xml->name);
+        $this->assertEquals('What is 2+2?', $xml->questiontext->text);
+        $this->assertEquals('moodle', $xml->questiontext['format']);
+        $this->assertEquals(2, count($xml->input));
+        $this->assertEquals(1, count($xml->prt));
+        $this->assertEquals('prt1', $xml->prt->name);
+        $this->assertEquals('0', $xml->node->name);
+        $this->assertEquals('011', $xml->node->sans);
+        $this->assertEquals('022', $xml->node->tans);
     }
 
     public function test_obj_diff(): void {

--- a/tests/yaml_converter_test.php
+++ b/tests/yaml_converter_test.php
@@ -37,14 +37,14 @@ if (is_file(__DIR__.'/../vendor/autoload.php')) {
  */
 final class yaml_converter_test extends \advanced_testcase {
 
-    public function test_loadxml(): void {
+    public function test_load_yaml_data(): void {
         if (!defined('Symfony\Component\Yaml\Yaml::DUMP_COMPACT_NESTED_MAPPING')) {
             $this->markTestSkipped('Symfony YAML extension is not available.');
             return;
         }
         $defaults = Yaml::parseFile(__DIR__ . '/../questiondefaults.yml');
         $questionyaml = file_get_contents(__DIR__ . '/fixtures/fullquestion.yml');
-        $xml = \qbank_gitsync\yaml_converter::loadyaml($questionyaml , $defaults);
+        $xml = \qbank_gitsync\yaml_converter::load_string_as_xml($questionyaml , $defaults);
         $this->assertEquals('Test question', (string) $xml->question->name->text);
         $this->assertEquals(1,
             preg_match('/<p>Question<\/p><p>\[\[input:ans1\]\] \[\[validation:ans1\]\]<\/p>\n    <p>' .
@@ -67,7 +67,6 @@ final class yaml_converter_test extends \advanced_testcase {
         $this->assertEquals('html', (string) $xml->question->questiondescription['format']);
 
         $this->assertEquals('1', (string) $xml->question->questionsimplify);
-        $this->assertEquals('0', (string) $xml->question->assumepositive);
         $this->assertEquals('0', (string) $xml->question->assumepositive);
         $this->assertEquals('<p><i class="fa fa-check"></i> Correct answer*, well done.</p>',
             (string) $xml->question->prtcorrect->text);
@@ -127,7 +126,7 @@ final class yaml_converter_test extends \advanced_testcase {
         $this->assertEquals('2', (string) $prt1->value);
         $this->assertEquals('1', (string) $prt1->autosimplify);
         $this->assertEquals('1', (string) $prt1->feedbackstyle);
-        $this->assertEquals('', (string) $prt1->feedbackvariables);
+        $this->assertEquals('', (string) $prt1->feedbackvariables->text);
         $this->assertCount(1, $prt1->node);
         $this->assertEquals('0', (string) $prt1->node[0]->name);
         $this->assertEquals('', (string) $prt1->node[0]->description);
@@ -190,6 +189,388 @@ final class yaml_converter_test extends \advanced_testcase {
         $this->assertEquals('2-0-T', (string) $qtest->expected[1]->expectedanswernote);
     }
 
+
+    public function test_load_xml_data(): void {
+        $defaults = yaml_converter::load_defaults(__DIR__ . '/../questiondefaults.xml', false);
+        $xmlstring = file_get_contents(__DIR__ . '/fixtures/fullquestion.xml');
+        $xml = \qbank_gitsync\yaml_converter::load_string_as_xml($xmlstring , $defaults, false);
+
+        $this->assertEquals('Test question', (string) $xml->question->name->text);
+        $this->assertEquals(1,
+            preg_match('/<p>Question<\/p><p>\[\[input:ans1\]\] \[\[validation:ans1\]\]<\/p>\n    <p>' .
+                '\[\[input:ans2\]\] \[\[validation:ans2\]\]<\/p>/s', (string) $xml->question->questiontext->text));
+        $this->assertEquals('html', (string) $xml->question->questiontext['format']);
+        $this->assertEquals(false, isset($xml->question->questiontext->format));
+        $this->assertEquals('', (string) $xml->question->generalfeedback->text);
+        $this->assertEquals('html', (string) $xml->question->generalfeedback['format']);
+        $this->assertEquals('1', (string) $xml->question->defaultgrade);
+        $this->assertEquals('0.1', (string) $xml->question->penalty);
+        $this->assertEquals('0', (string) $xml->question->hidden);
+        $this->assertEquals('', (string) $xml->question->idnumber);
+        $this->assertEquals('2025042500', (string) $xml->question->stackversion->text);
+        $this->assertEquals('ta1:1;ta2:2;', (string) $xml->question->questionvariables->text);
+        $this->assertEquals('[[feedback:prt1]]', (string) $xml->question->specificfeedback->text);
+        $this->assertEquals('html', (string) $xml->question->specificfeedback['format']);
+        $this->assertEquals('{@ta1@}', (string) $xml->question->questionnote->text);
+        $this->assertEquals('html', (string) $xml->question->questionnote['format']);
+        $this->assertEquals('', (string) $xml->question->questiondescription->text);
+        $this->assertEquals('html', (string) $xml->question->questiondescription['format']);
+
+        $this->assertEquals('1', (string) $xml->question->questionsimplify);
+        $this->assertEquals('0', (string) $xml->question->assumepositive);
+        $this->assertEquals('<p><i class="fa fa-check"></i> Correct answer*, well done.</p>',
+            (string) $xml->question->prtcorrect->text);
+        $this->assertEquals('html', (string) $xml->question->prtcorrect['format']);
+        $this->assertEquals('<span style="font-size: 1.5em; color:orange;"><i class="fa fa-adjust"></i></span> Your answer is partially correct.',
+            (string) $xml->question->prtpartiallycorrect->text);
+        $this->assertEquals('html', (string) $xml->question->prtpartiallycorrect['format']);
+        $this->assertEquals('<span style="font-size: 1.5em; color:red;"><i class="fa fa-times"></i></span> Incorrect answer.',
+            (string) $xml->question->prtincorrect->text);
+        $this->assertEquals('html', (string) $xml->question->prtincorrect['format']);
+        $this->assertEquals('.', (string) $xml->question->decimals);
+        $this->assertEquals('*10', (string) $xml->question->scientificnotation);
+        $this->assertEquals('cross', (string) $xml->question->multiplicationsign);
+        $this->assertEquals('1', (string) $xml->question->sqrtsign);
+        $this->assertEquals('i', (string) $xml->question->complexno);
+        $this->assertEquals('cos-1', (string) $xml->question->inversetrig);
+        $this->assertEquals('lang', (string) $xml->question->logicsymbol);
+        $this->assertEquals('[', (string) $xml->question->matrixparens);
+        $this->assertEquals('0', (string) $xml->question->isbroken);
+        $this->assertEquals('', (string) $xml->question->variantsselectionseed);
+
+        // Check input fields.
+        $this->assertCount(2, $xml->question->input);
+        $input1 = $xml->question->input[0];
+        $input2 = $xml->question->input[1];
+        $this->assertEquals('ans1', (string) $input1->name);
+        $this->assertEquals('algebraic', (string) $input1->type);
+        $this->assertEquals('ta1', (string) $input1->tans);
+        $this->assertEquals('25', (string) $input1->boxsize);
+        $this->assertEquals('1', (string) $input1->strictsyntax);
+        $this->assertEquals('0', (string) $input1->insertstars);
+        $this->assertEquals('', (string) $input1->syntaxhint);
+        $this->assertEquals('0', (string) $input1->syntaxattribute);
+        $this->assertEquals('', (string) $input1->forbidwords);
+        $this->assertEquals('', (string) $input1->allowwords);
+        $this->assertEquals('1', (string) $input1->forbidfloat);
+        $this->assertEquals('0', (string) $input1->requirelowestterms);
+        $this->assertEquals('0', (string) $input1->checkanswertype);
+        $this->assertEquals('1', (string) $input1->mustverify);
+        $this->assertEquals('1', (string) $input1->showvalidation);
+        $this->assertEquals('', (string) $input1->options);
+
+        $this->assertEquals('ans2', (string) $input2->name);
+        $this->assertEquals('algebraic', (string) $input2->type);
+        $this->assertEquals('ta2', (string) $input2->tans);
+        $this->assertEquals('1', (string) $input2->forbidfloat);
+        $this->assertEquals('0', (string) $input2->requirelowestterms);
+        $this->assertEquals('0', (string) $input2->checkanswertype);
+        $this->assertEquals('1', (string) $input2->mustverify);
+        $this->assertEquals('1', (string) $input2->showvalidation);
+
+        // Check prt fields.
+        $this->assertCount(2, $xml->question->prt);
+        $prt1 = $xml->question->prt[0];
+        $prt2 = $xml->question->prt[1];
+        $this->assertEquals('prt1', (string) $prt1->name);
+        $this->assertEquals('2', (string) $prt1->value);
+        $this->assertEquals('1', (string) $prt1->autosimplify);
+        $this->assertEquals('1', (string) $prt1->feedbackstyle);
+        $this->assertEquals('', (string) $prt1->feedbackvariables->text);
+        $this->assertCount(1, $prt1->node);
+        $this->assertEquals('0', (string) $prt1->node[0]->name);
+        $this->assertEquals('', (string) $prt1->node[0]->description);
+        $this->assertEquals('AlgEquiv', (string) $prt1->node[0]->answertest);
+        $this->assertEquals('ans1', (string) $prt1->node[0]->sans);
+        $this->assertEquals('ta1', (string) $prt1->node[0]->tans);
+        $this->assertEquals('', (string) $prt1->node[0]->testoptions);
+        $this->assertEquals('1', (string) $prt1->node[0]->quiet);
+        $this->assertEquals('=', (string) $prt1->node[0]->truescoremode);
+        $this->assertEquals('1', (string) $prt1->node[0]->truescore);
+        $this->assertEquals('', (string) $prt1->node[0]->truepenalty);
+        $this->assertEquals('-1', (string) $prt1->node[0]->truenextnode);
+        $this->assertEquals('prt1-1-T', (string) $prt1->node[0]->trueanswernote);
+        $this->assertEquals('', (string) $prt1->node[0]->truefeedback->text);
+        $this->assertEquals('html', (string) $prt1->node[0]->truefeedback['format']);
+        $this->assertEquals('=', (string) $prt1->node[0]->falsescoremode);
+        $this->assertEquals('0', (string) $prt1->node[0]->falsescore);
+        $this->assertEquals('', (string) $prt1->node[0]->falsepenalty);
+        $this->assertEquals('-1', (string) $prt1->node[0]->falsenextnode);
+        $this->assertEquals('prt1-1-F', (string) $prt1->node[0]->falseanswernote);
+        $this->assertEquals('', (string) $prt1->node[0]->falsefeedback->text);
+        $this->assertEquals('html', (string) $prt1->node[0]->falsefeedback['format']);
+
+        $this->assertEquals('prt2', (string) $prt2->name);
+        $this->assertEquals('1.0000001', (string) $prt2->value);
+        $this->assertEquals('1', (string) $prt2->autosimplify);
+        $this->assertEquals('1', (string) $prt2->feedbackstyle);
+        $this->assertCount(1, $prt2->node);
+        $this->assertEquals('0', (string) $prt2->node[0]->name);
+        $this->assertEquals('AlgEquiv', (string) $prt2->node[0]->answertest);
+        $this->assertEquals('ans2', (string) $prt2->node[0]->sans);
+        $this->assertEquals('ta2', (string) $prt2->node[0]->tans);
+        $this->assertEquals('0', (string) $prt2->node[0]->quiet);
+        $this->assertEquals('1', (string) $prt2->node[0]->falsescore);
+
+        // Check deployedseed.
+        $this->assertCount(3, $xml->question->deployedseed);
+        $this->assertEquals('1', (string) $xml->question->deployedseed[0]);
+        $this->assertEquals('2', (string) $xml->question->deployedseed[1]);
+        $this->assertEquals('3', (string) $xml->question->deployedseed[2]);
+
+        // Check qtest.
+        $this->assertCount(1, $xml->question->qtest);
+        $qtest = $xml->question->qtest[0];
+        $this->assertEquals('1', (string) $qtest->testcase);
+        $this->assertEquals('A test', (string) $qtest->description);
+        $this->assertCount(2, $qtest->testinput);
+        $this->assertEquals('ans1', (string) $qtest->testinput[0]->name);
+        $this->assertEquals('ta1', (string) $qtest->testinput[0]->value);
+        $this->assertEquals('ans2', (string) $qtest->testinput[1]->name);
+        $this->assertEquals('ta2', (string) $qtest->testinput[1]->value);
+        $this->assertCount(2, $qtest->expected);
+        $this->assertEquals('prt1', (string) $qtest->expected[0]->name);
+        $this->assertEquals('1.0000000', (string) $qtest->expected[0]->expectedscore);
+        $this->assertEquals('0.0000000', (string) $qtest->expected[0]->expectedpenalty);
+        $this->assertEquals('1-0-T', (string) $qtest->expected[0]->expectedanswernote);
+        $this->assertEquals('prt2', (string) $qtest->expected[1]->name);
+        $this->assertEquals('1.0000000', (string) $qtest->expected[1]->expectedscore);
+        $this->assertEquals('0.0000000', (string) $qtest->expected[1]->expectedpenalty);
+        $this->assertEquals('2-0-T', (string) $qtest->expected[1]->expectedanswernote);
+    }
+
+    public function test_load_xml_frag_data(): void {
+        $defaults = yaml_converter::load_defaults(__DIR__ . '/../questiondefaults.xml', false);
+        $xmlstring = '<quiz><question type="stack"></question></quiz>';
+        $question = \qbank_gitsync\yaml_converter::load_string_as_xml($xmlstring, $defaults, false);
+        $question = $question->question;
+        $this->assertEquals('Default', $question->name->text);
+        $this->assertEquals(
+            '<p>Default question</p><p>[[input:ans1]] [[validation:ans1]]</p>',
+             $question->questiontext->text
+        );
+        $this->assertEquals('html', $question->questiontext['format']);
+        $this->assertEquals(
+            '',
+             $question->generalfeedback->text
+        );
+        $this->assertEquals('html', $question->generalfeedback['format']);
+        $this->assertEquals(
+            '<span style="font-size: 1.5em; color:green;"><i class="fa fa-check"></i></span> Correct answer, well done.',
+             $question->prtcorrect->text
+        );
+        $this->assertEquals('html', $question->prtpartiallycorrect['format']);
+        $this->assertEquals(
+            '<span style="font-size: 1.5em; color:orange;"><i class="fa fa-adjust"></i></span> Your answer is partially correct.',
+             $question->prtpartiallycorrect->text
+        );
+        $this->assertEquals('html', $question->prtincorrect['format']);
+        $this->assertEquals(
+            '<span style="font-size: 1.5em; color:red;"><i class="fa fa-times"></i></span> Incorrect answer.',
+             $question->prtincorrect->text
+        );
+        $this->assertEquals('html', $question->prtcorrect['format']);
+        $this->assertEquals('1', $question->defaultgrade);
+        $this->assertEquals('0.1', $question->penalty);
+        $this->assertEquals('0', $question->hidden);
+        $this->assertEquals(
+            '2025042500',
+            $question->stackversion->text
+        );
+        $this->assertEquals(
+            'ta1:1;',
+            $question->questionvariables->text
+        );
+        $this->assertEquals(
+            '[[feedback:prt1]]',
+             $question->specificfeedback->text
+        );
+        $this->assertEquals('html', $question->specificfeedback['format']);
+        $this->assertEquals(
+            '{@ta1@}',
+             $question->questionnote->text
+        );
+        $this->assertEquals('html', $question->questionnote['format']);
+        $this->assertEquals(
+            '',
+             $question->questiondescription->text
+        );
+        $this->assertEquals('html', $question->questiondescription['format']);
+
+        $this->assertEquals('.', $question->decimals);
+        $this->assertEquals('*10', $question->scientificnotation, );
+        $this->assertEquals('0', $question->assumepositive);
+        $this->assertEquals('0', $question->assumereal);
+        $this->assertEquals('dot', $question->multiplicationsign);
+        $this->assertEquals('1', $question->sqrtsign);
+        $this->assertEquals('i', $question->complexno);
+        $this->assertEquals('lang', $question->logicsymbol);
+        $this->assertEquals('cos-1', $question->inversetrig);
+        $this->assertEquals('[', $question->matrixparens);
+        $this->assertEquals('1', $question->questionsimplify);
+        $this->assertEquals('0', $question->isbroken);
+
+        $this->assertEquals('1', $question->prt[0]->value);
+        $this->assertEquals('1', $question->prt[0]->autosimplify);
+        $this->assertEquals('1', $question->prt[0]->feedbackstyle);
+        $this->assertEquals('', $question->prt[0]->feedbackvariables);
+
+        $this->assertEquals('', $question->prt[0]->node[0]->description);
+        $this->assertEquals('AlgEquiv', $question->prt[0]->node[0]->answertest);
+        $this->assertEquals('ans1', $question->prt[0]->node[0]->sans);
+        $this->assertEquals('ta1', $question->prt[0]->node[0]->tans);
+        $this->assertEquals('0', $question->prt[0]->node[0]->quiet);
+        $this->assertEquals('', $question->prt[0]->node[0]->testoptions);
+        $this->assertEquals('-1', $question->prt[0]->node[0]->truenextnode);
+        $this->assertEquals('prt1-1-T', $question->prt[0]->node[0]->trueanswernote);
+        $this->assertEquals('1', $question->prt[0]->node[0]->truescore);
+        $this->assertEquals('', $question->prt[0]->node[0]->truepenalty);
+        $this->assertEquals('=', $question->prt[0]->node[0]->truescoremode);
+        $this->assertEquals('', $question->prt[0]->node[0]->truefeedback->text);
+        $this->assertEquals('html', $question->prt[0]->node[0]->truefeedback['format']);
+        $this->assertEquals('=', $question->prt[0]->node[0]->truescoremode);
+        $this->assertEquals('-1', $question->prt[0]->node[0]->falsenextnode);
+        $this->assertEquals('prt1-1-F', $question->prt[0]->node[0]->falseanswernote);
+        $this->assertEquals('0', $question->prt[0]->node[0]->falsescore);
+        $this->assertEquals('=', $question->prt[0]->node[0]->falsescoremode);
+        $this->assertEquals('', $question->prt[0]->node[0]->falsepenalty);
+        $this->assertEquals('', $question->prt[0]->node[0]->falsefeedback->text);
+        $this->assertEquals('html', $question->prt[0]->node[0]->falsefeedback['format']);
+        $input1 = $question->input[0];
+        $this->assertEquals('ans1', (string) $input1->name);
+        $this->assertEquals('algebraic', (string) $input1->type);
+        $this->assertEquals('ta1', (string) $input1->tans);
+        $this->assertEquals('15', (string) $input1->boxsize);
+        $this->assertEquals('1', (string) $input1->strictsyntax);
+        $this->assertEquals('0', (string) $input1->insertstars);
+        $this->assertEquals('', (string) $input1->syntaxhint);
+        $this->assertEquals('0', (string) $input1->syntaxattribute);
+        $this->assertEquals('', (string) $input1->forbidwords);
+        $this->assertEquals('', (string) $input1->allowwords);
+        $this->assertEquals('1', (string) $input1->forbidfloat);
+        $this->assertEquals('0', (string) $input1->requirelowestterms);
+        $this->assertEquals('0', (string) $input1->checkanswertype);
+        $this->assertEquals('1', (string) $input1->mustverify);
+        $this->assertEquals('1', (string) $input1->showvalidation);
+        $this->assertEquals('', (string) $input1->options);
+    }
+
+    public function test_load_yml_frag_data(): void {
+        $defaults = yaml_converter::load_defaults(__DIR__ . '/../questiondefaults.yml', true);
+        $yamlstring = 'name: Default';
+        $question = \qbank_gitsync\yaml_converter::load_string_as_xml($yamlstring, $defaults, true);
+        $question = $question->question;
+        $this->assertEquals('Default', $question->name->text);
+        $this->assertEquals(
+            '<p>Default question</p><p>[[input:ans1]] [[validation:ans1]]</p>',
+             $question->questiontext->text
+        );
+        $this->assertEquals('html', $question->questiontext['format']);
+        $this->assertEquals(
+            '',
+             $question->generalfeedback->text
+        );
+        $this->assertEquals('html', $question->generalfeedback['format']);
+        $this->assertEquals(
+            '<span style="font-size: 1.5em; color:green;"><i class="fa fa-check"></i></span> Correct answer, well done.',
+             $question->prtcorrect->text
+        );
+        $this->assertEquals('html', $question->prtpartiallycorrect['format']);
+        $this->assertEquals(
+            '<span style="font-size: 1.5em; color:orange;"><i class="fa fa-adjust"></i></span> Your answer is partially correct.',
+             $question->prtpartiallycorrect->text
+        );
+        $this->assertEquals('html', $question->prtincorrect['format']);
+        $this->assertEquals(
+            '<span style="font-size: 1.5em; color:red;"><i class="fa fa-times"></i></span> Incorrect answer.',
+             $question->prtincorrect->text
+        );
+        $this->assertEquals('html', $question->prtcorrect['format']);
+        $this->assertEquals('1', $question->defaultgrade);
+        $this->assertEquals('0.1', $question->penalty);
+        $this->assertEquals('0', $question->hidden);
+        $this->assertEquals(
+            '2025042500',
+            $question->stackversion->text
+        );
+        $this->assertEquals(
+            'ta1:1;',
+            $question->questionvariables->text
+        );
+        $this->assertEquals(
+            '[[feedback:prt1]]',
+             $question->specificfeedback->text
+        );
+        $this->assertEquals('html', $question->specificfeedback['format']);
+        $this->assertEquals(
+            '{@ta1@}',
+             $question->questionnote->text
+        );
+        $this->assertEquals('html', $question->questionnote['format']);
+        $this->assertEquals(
+            '',
+             $question->questiondescription->text
+        );
+        $this->assertEquals('html', $question->questiondescription['format']);
+
+        $this->assertEquals('.', $question->decimals);
+        $this->assertEquals('*10', $question->scientificnotation, );
+        $this->assertEquals('0', $question->assumepositive);
+        $this->assertEquals('0', $question->assumereal);
+        $this->assertEquals('dot', $question->multiplicationsign);
+        $this->assertEquals('1', $question->sqrtsign);
+        $this->assertEquals('i', $question->complexno);
+        $this->assertEquals('lang', $question->logicsymbol);
+        $this->assertEquals('cos-1', $question->inversetrig);
+        $this->assertEquals('[', $question->matrixparens);
+        $this->assertEquals('1', $question->questionsimplify);
+        $this->assertEquals('0', $question->isbroken);
+
+        $this->assertEquals('1', $question->prt[0]->value);
+        $this->assertEquals('1', $question->prt[0]->autosimplify);
+        $this->assertEquals('1', $question->prt[0]->feedbackstyle);
+        $this->assertEquals('', $question->prt[0]->feedbackvariables);
+
+        $this->assertEquals('', $question->prt[0]->node[0]->description);
+        $this->assertEquals('AlgEquiv', $question->prt[0]->node[0]->answertest);
+        $this->assertEquals('ans1', $question->prt[0]->node[0]->sans);
+        $this->assertEquals('ta1', $question->prt[0]->node[0]->tans);
+        $this->assertEquals('0', $question->prt[0]->node[0]->quiet);
+        $this->assertEquals('', $question->prt[0]->node[0]->testoptions);
+        $this->assertEquals('-1', $question->prt[0]->node[0]->truenextnode);
+        $this->assertEquals('prt1-1-T', $question->prt[0]->node[0]->trueanswernote);
+        $this->assertEquals('1', $question->prt[0]->node[0]->truescore);
+        $this->assertEquals('', $question->prt[0]->node[0]->truepenalty);
+        $this->assertEquals('=', $question->prt[0]->node[0]->truescoremode);
+        $this->assertEquals('', $question->prt[0]->node[0]->truefeedback->text);
+        $this->assertEquals('html', $question->prt[0]->node[0]->truefeedback['format']);
+        $this->assertEquals('=', $question->prt[0]->node[0]->truescoremode);
+        $this->assertEquals('-1', $question->prt[0]->node[0]->falsenextnode);
+        $this->assertEquals('prt1-1-F', $question->prt[0]->node[0]->falseanswernote);
+        $this->assertEquals('0', $question->prt[0]->node[0]->falsescore);
+        $this->assertEquals('=', $question->prt[0]->node[0]->falsescoremode);
+        $this->assertEquals('', $question->prt[0]->node[0]->falsepenalty);
+        $this->assertEquals('', $question->prt[0]->node[0]->falsefeedback->text);
+        $this->assertEquals('html', $question->prt[0]->node[0]->falsefeedback['format']);
+        $input1 = $question->input[0];
+        $this->assertEquals('ans1', (string) $input1->name);
+        $this->assertEquals('algebraic', (string) $input1->type);
+        $this->assertEquals('ta1', (string) $input1->tans);
+        $this->assertEquals('15', (string) $input1->boxsize);
+        $this->assertEquals('1', (string) $input1->strictsyntax);
+        $this->assertEquals('0', (string) $input1->insertstars);
+        $this->assertEquals('', (string) $input1->syntaxhint);
+        $this->assertEquals('0', (string) $input1->syntaxattribute);
+        $this->assertEquals('', (string) $input1->forbidwords);
+        $this->assertEquals('', (string) $input1->allowwords);
+        $this->assertEquals('1', (string) $input1->forbidfloat);
+        $this->assertEquals('0', (string) $input1->requirelowestterms);
+        $this->assertEquals('0', (string) $input1->checkanswertype);
+        $this->assertEquals('1', (string) $input1->mustverify);
+        $this->assertEquals('1', (string) $input1->showvalidation);
+        $this->assertEquals('', (string) $input1->options);
+    }
+
     public function test_loadxml_summary_default(): void {
         if (!defined('Symfony\Component\Yaml\Yaml::DUMP_COMPACT_NESTED_MAPPING')) {
             $this->markTestSkipped('Symfony YAML extension is not available.');
@@ -197,7 +578,7 @@ final class yaml_converter_test extends \advanced_testcase {
         }
         $defaults = Yaml::parseFile(__DIR__ . '/fixtures/questiondefaultssugar.yml');
         $questionyaml = file_get_contents(__DIR__ . '/fixtures/fullquestion.yml');
-        $xml = \qbank_gitsync\yaml_converter::loadyaml($questionyaml , $defaults);
+        $xml = \qbank_gitsync\yaml_converter::load_string_as_xml($questionyaml , $defaults);
 
         // Check prt fields.
         $this->assertCount(2, $xml->question->prt);
@@ -229,7 +610,7 @@ final class yaml_converter_test extends \advanced_testcase {
         }
         $defaults = Yaml::parseFile(__DIR__ . '/fixtures/questiondefaultssugar.yml');
         $questionyaml = file_get_contents(__DIR__ . '/fixtures/fullquestionsummary.yml');
-        $xml = \qbank_gitsync\yaml_converter::loadyaml($questionyaml , $defaults);
+        $xml = \qbank_gitsync\yaml_converter::load_string_as_xml($questionyaml , $defaults);
 
         // Check prt fields.
         $this->assertCount(2, $xml->question->prt);
@@ -466,7 +847,7 @@ final class yaml_converter_test extends \advanced_testcase {
         $this->assertEquals(10, count($diffarray));
         $expected = [
             'name' => 'Test question',
-            'questiontext' => "<p>Question</p><p>[[input:ans1]] [[validation:ans1]]</p>\n<p>[[input:ans2]] " .
+            'questiontext' => "<p>Question</p><p>[[input:ans1]] [[validation:ans1]]</p>\n    <p>[[input:ans2]] " .
                 "[[validation:ans2]]</p>",
             'questionvariables' => 'ta1:1;ta2:2;',
             'questionsimplify' => '1',
@@ -563,7 +944,7 @@ final class yaml_converter_test extends \advanced_testcase {
             ],
         ];
         $expectedstring = "name: 'Test question'\nquestiontext: |-\n  <p>Question</p><p>[[input:ans1]] [[validation:ans1]]</p>" .
-            "\n  <p>[[input:ans2]] [[validation:ans2]]</p>\nquestionvariables: 'ta1:1;ta2:2;" .
+            "\n      <p>[[input:ans2]] [[validation:ans2]]</p>\nquestionvariables: 'ta1:1;ta2:2;" .
             "'\nquestionsimplify: '1'\nprtcorrect: '<p>" .
             "<i class=\"fa fa-check\"></i> Correct answer*, well done.</p>'\nmultiplicationsign: cross\ninput:\n  - " .
             "name: ans1\n    type: algebraic\n    tans: ta1\n    boxsize: '25'\n    forbidfloat: '1'\n    " .

--- a/tests/yaml_converter_test.php
+++ b/tests/yaml_converter_test.php
@@ -454,20 +454,20 @@ final class yaml_converter_test extends \advanced_testcase {
         $this->assertStringContainsString('name: Test', $yaml);
     }
 
-    public function test_detect_difference_yml(): void {
+    public function test_detect_difference_xml(): void {
         if (!defined('Symfony\Component\Yaml\Yaml::DUMP_COMPACT_NESTED_MAPPING')) {
             $this->markTestSkipped('Symfony YAML extension is not available.');
             return;
         }
         // Test the difference detection with a full question.
-        $yaml = file_get_contents(__DIR__ . '/fixtures/fullquestion.yml');
-        $diff = yaml_converter::detect_differences($yaml, null);
+        $xml = file_get_contents(__DIR__ . '/fixtures/fullquestion.xml');
+        $diff = yaml_converter::detect_differences($xml, null, true);
         $diffarray = Yaml::parse($diff);
         $this->assertEquals(10, count($diffarray));
         $expected = [
             'name' => 'Test question',
-            'questiontext' => "<p>Question</p><p>[[input:ans1]] [[validation:ans1]]</p>\n    <p>[[input:ans2]] " .
-                "[[validation:ans2]]</p>\n",
+            'questiontext' => "<p>Question</p><p>[[input:ans1]] [[validation:ans1]]</p>\n<p>[[input:ans2]] " .
+                "[[validation:ans2]]</p>",
             'questionvariables' => 'ta1:1;ta2:2;',
             'questionsimplify' => '1',
             'prtcorrect' => '<p><i class="fa fa-check"></i> Correct answer*, well done.</p>',
@@ -562,8 +562,8 @@ final class yaml_converter_test extends \advanced_testcase {
                 ],
             ],
         ];
-        $expectedstring = "name: 'Test question'\nquestiontext: |\n  <p>Question</p><p>[[input:ans1]] [[validation:ans1]]</p>" .
-            "\n      <p>[[input:ans2]] [[validation:ans2]]</p>\nquestionvariables: 'ta1:1;ta2:2;" .
+        $expectedstring = "name: 'Test question'\nquestiontext: |-\n  <p>Question</p><p>[[input:ans1]] [[validation:ans1]]</p>" .
+            "\n  <p>[[input:ans2]] [[validation:ans2]]</p>\nquestionvariables: 'ta1:1;ta2:2;" .
             "'\nquestionsimplify: '1'\nprtcorrect: '<p>" .
             "<i class=\"fa fa-check\"></i> Correct answer*, well done.</p>'\nmultiplicationsign: cross\ninput:\n  - " .
             "name: ans1\n    type: algebraic\n    tans: ta1\n    boxsize: '25'\n    forbidfloat: '1'\n    " .
@@ -585,7 +585,7 @@ final class yaml_converter_test extends \advanced_testcase {
 
         // Check results when using answertest summary in defaults.
         $diff = yaml_converter::detect_differences(
-            $yaml,
+            $xml,
             yaml_converter::load_defaults(__DIR__ . '/fixtures/questiondefaultssugar.yml')
         );
         $diffarray = Yaml::parse($diff);

--- a/tests/yaml_converter_test.php
+++ b/tests/yaml_converter_test.php
@@ -374,7 +374,7 @@ final class yaml_converter_test extends \advanced_testcase {
         $this->assertEquals('0.1', $question->penalty);
         $this->assertEquals('0', $question->hidden);
         $this->assertEquals(
-            '2025042500',
+            $defaults['question']['stackversion'],
             $question->stackversion->text
         );
         $this->assertEquals(
@@ -490,7 +490,7 @@ final class yaml_converter_test extends \advanced_testcase {
         $this->assertEquals('0.1', $question->penalty);
         $this->assertEquals('0', $question->hidden);
         $this->assertEquals(
-            '2025042500',
+            $defaults['question']['stackversion'],
             $question->stackversion->text
         );
         $this->assertEquals(
@@ -844,11 +844,12 @@ final class yaml_converter_test extends \advanced_testcase {
         $xml = file_get_contents(__DIR__ . '/fixtures/fullquestion.xml');
         $diff = yaml_converter::detect_differences($xml, null, true);
         $diffarray = Yaml::parse($diff);
-        $this->assertEquals(10, count($diffarray));
+        $this->assertEquals(11, count($diffarray));
         $expected = [
             'name' => 'Test question',
             'questiontext' => "<p>Question</p><p>[[input:ans1]] [[validation:ans1]]</p>\n    <p>[[input:ans2]] " .
                 "[[validation:ans2]]</p>",
+            'stackversion' => '2025042500',
             'questionvariables' => 'ta1:1;ta2:2;',
             'questionsimplify' => '1',
             'prtcorrect' => '<p><i class="fa fa-check"></i> Correct answer*, well done.</p>',
@@ -944,7 +945,7 @@ final class yaml_converter_test extends \advanced_testcase {
             ],
         ];
         $expectedstring = "name: 'Test question'\nquestiontext: |-\n  <p>Question</p><p>[[input:ans1]] [[validation:ans1]]</p>" .
-            "\n      <p>[[input:ans2]] [[validation:ans2]]</p>\nquestionvariables: 'ta1:1;ta2:2;" .
+            "\n      <p>[[input:ans2]] [[validation:ans2]]</p>\nstackversion: '2025042500'\nquestionvariables: 'ta1:1;ta2:2;" .
             "'\nquestionsimplify: '1'\nprtcorrect: '<p>" .
             "<i class=\"fa fa-check\"></i> Correct answer*, well done.</p>'\nmultiplicationsign: cross\ninput:\n  - " .
             "name: ans1\n    type: algebraic\n    tans: ta1\n    boxsize: '25'\n    forbidfloat: '1'\n    " .
@@ -970,7 +971,7 @@ final class yaml_converter_test extends \advanced_testcase {
             yaml_converter::load_defaults(__DIR__ . '/fixtures/questiondefaultssugar.yml')
         );
         $diffarray = Yaml::parse($diff);
-        $this->assertEquals(10, count($diffarray));
+        $this->assertEquals(11, count($diffarray));
         $expected['prt'][0]['node'][0] = [
                             'name' => '0',
                             'answertest' => 'ATAlgEquiv(ans1,ta1)',
@@ -1113,6 +1114,28 @@ final class yaml_converter_test extends \advanced_testcase {
             'foo ( bar )',
             'baz',
             'qux',
+        ];
+        $this->assertEquals($expected, yaml_converter::split_answertest($input));
+    }
+
+    public function test_split_answertest_square(): void {
+        $input = 'ATTest( foo[bar, again], baz , qux )';
+        $expected = [
+            'ATTest',
+            'foo[bar, again]',
+            'baz',
+            'qux',
+        ];
+        $this->assertEquals($expected, yaml_converter::split_answertest($input));
+    }
+
+    public function test_split_answertest_mix(): void {
+        $input = 'ATTest( foo[bar, (again, hello)], ([baz, baz]), ([qux, qux2]) )';
+        $expected = [
+            'ATTest',
+            'foo[bar, (again, hello)]',
+            '([baz, baz])',
+            '([qux, qux2])',
         ];
         $this->assertEquals($expected, yaml_converter::split_answertest($input));
     }

--- a/version.php
+++ b/version.php
@@ -25,7 +25,7 @@
 defined('MOODLE_INTERNAL') || die();
 
 // Should match GITSYNC_VERSION in cli_helper.
-$plugin->version   = 2025101400;
+$plugin->version   = 2025111300;
 // Question versions functionality of Moodle 4 required.
 // Question delete fix for Moodle 4.1.5 required.
 // NB 4.2.0 and 4.2.1 do not have the fix.


### PR DESCRIPTION
- Separate using YAML and using fragments into different options, thus allowing XML frags and full YAML questions.
- Add default PRT/input when importing frags. Make defaults consistent with STACK.
- Catch mal-formed YAML/XML. 
- Update tests and docs.
- Allow use of 'Continue?' rather than 'Abort?'
- Output accepted parameters when running command line scripts.
- Display whether expecting YAML/XML and frag/full questions when running scripts.
- Update docs about frags.
- Display validation warnings when importing questions to Moodle. Relies on update to importasversion but won't break without. - TODO Update importasversion requirement once new version available.
- TODO Code tidy (including latest Code Checker update)