### PR TITLE
Update default feedback options to match STACK.  #98.

### DIFF
--- a/questiondefaults.xml
+++ b/questiondefaults.xml
@@ -30,13 +30,13 @@
     <assumepositive>0</assumepositive>
     <assumereal>0</assumereal>
     <prtcorrect format="html">
-      <text><![CDATA[<span style="font-size: 1.5em; color:green;"><i class="fa fa-check"></i></span> Correct answer, well done.]]></text>
+      <text><![CDATA[[[commonstring key="symbolicprtcorrectfeedback"/]] [[commonstring key="defaultprtcorrectfeedback"/]]]]></text>
     </prtcorrect>
     <prtpartiallycorrect format="html">
-      <text><![CDATA[<span style="font-size: 1.5em; color:orange;"><i class="fa fa-adjust"></i></span> Your answer is partially correct.]]></text>
+      <text><![CDATA[[[commonstring key="symbolicprtpartiallycorrectfeedback"/]] [[commonstring key="defaultprtpartiallycorrectfeedback"/]]]]></text>
     </prtpartiallycorrect>
     <prtincorrect format="html">
-      <text><![CDATA[<span style="font-size: 1.5em; color:red;"><i class="fa fa-times"></i></span> Incorrect answer.]]></text>
+      <text><![CDATA[[[commonstring key="symbolicprtincorrectfeedback"/]] [[commonstring key="defaultprtincorrectfeedback"/]]]]></text>
     </prtincorrect>
     <decimals>.</decimals>
     <scientificnotation>*10</scientificnotation>

--- a/questiondefaults.yml
+++ b/questiondefaults.yml
@@ -20,11 +20,11 @@ question:
   questionsimplify: '1'
   assumepositive: '0'
   assumereal: '0'
-  prtcorrect: '<span style="font-size: 1.5em; color:green;"><i class="fa fa-check"></i></span> Correct answer, well done.'
+  prtcorrect: '[[commonstring key="symbolicprtcorrectfeedback"/]] [[commonstring key="defaultprtcorrectfeedback"/]]'
   prtcorrectformat: html
-  prtpartiallycorrect: '<span style="font-size: 1.5em; color:orange;"><i class="fa fa-adjust"></i></span> Your answer is partially correct.'
+  prtpartiallycorrect: '[[commonstring key="symbolicprtpartiallycorrectfeedback"/]] [[commonstring key="defaultprtpartiallycorrectfeedback"/]]'
   prtpartiallycorrectformat: html
-  prtincorrect: '<span style="font-size: 1.5em; color:red;"><i class="fa fa-times"></i></span> Incorrect answer.'
+  prtincorrect: '[[commonstring key="symbolicprtincorrectfeedback"/]] [[commonstring key="defaultprtincorrectfeedback"/]]'
   prtincorrectformat: html
   decimals: .
   scientificnotation: '*10'

--- a/tests/fixtures/fullquestion.xml
+++ b/tests/fixtures/fullquestion.xml
@@ -37,10 +37,10 @@
       <text><![CDATA[<p><i class="fa fa-check"></i> Correct answer*, well done.</p>]]></text>
     </prtcorrect>
     <prtpartiallycorrect format="html">
-      <text><![CDATA[<span style="font-size: 1.5em; color:orange;"><i class="fa fa-adjust"></i></span> Your answer is partially correct.]]></text>
+      <text><![CDATA[[[commonstring key="symbolicprtpartiallycorrectfeedback"/]] [[commonstring key="defaultprtpartiallycorrectfeedback"/]]]]></text>
     </prtpartiallycorrect>
     <prtincorrect format="html">
-      <text><![CDATA[<span style="font-size: 1.5em; color:red;"><i class="fa fa-times"></i></span> Incorrect answer.]]></text>
+      <text><![CDATA[[[commonstring key="symbolicprtincorrectfeedback"/]] [[commonstring key="defaultprtincorrectfeedback"/]]]]></text>
     </prtincorrect>
     <decimals>.</decimals>
     <scientificnotation>*10</scientificnotation>

--- a/tests/fixtures/fullquestion.yml
+++ b/tests/fixtures/fullquestion.yml
@@ -22,9 +22,9 @@ assumepositive: 0
 assumereal: 0
 prtcorrect: <p><i class="fa fa-check"></i> Correct answer*, well done.</p>
 prtcorrectformat: html
-prtpartiallycorrect: '<span style="font-size: 1.5em; color:orange;"><i class="fa fa-adjust"></i></span> Your answer is partially correct.'
+prtpartiallycorrect: '[[commonstring key="symbolicprtpartiallycorrectfeedback"/]] [[commonstring key="defaultprtpartiallycorrectfeedback"/]]'
 prtpartiallycorrectformat: html
-prtincorrect: '<span style="font-size: 1.5em; color:red;"><i class="fa fa-times"></i></span> Incorrect answer.'
+prtincorrect: '[[commonstring key="symbolicprtincorrectfeedback"/]] [[commonstring key="defaultprtincorrectfeedback"/]]'
 prtincorrectformat: html
 decimals: .
 scientificnotation: '*10'

--- a/tests/fixtures/fullquestionsummary.yml
+++ b/tests/fixtures/fullquestionsummary.yml
@@ -22,9 +22,9 @@ assumepositive: 0
 assumereal: 0
 prtcorrect: <p><i class="fa fa-check"></i> Correct answer*, well done.</p>
 prtcorrectformat: html
-prtpartiallycorrect: <p><i class="fa fa-adjust"></i> Your answer is partially correct.</p>
+prtpartiallycorrect: '[[commonstring key="symbolicprtpartiallycorrectfeedback"/]] [[commonstring key="defaultprtpartiallycorrectfeedback"/]]'
 prtpartiallycorrectformat: html
-prtincorrect: <p><i class="fa fa-times"></i> Incorrect answer.</p>
+prtincorrect: '[[commonstring key="symbolicprtincorrectfeedback"/]] [[commonstring key="defaultprtincorrectfeedback"/]]'
 prtincorrectformat: html
 decimals: .
 scientificnotation: '*10'

--- a/tests/fixtures/questiondefaultssugar.yml
+++ b/tests/fixtures/questiondefaultssugar.yml
@@ -20,11 +20,11 @@ question:
   questionsimplify: '1'
   assumepositive: '0'
   assumereal: '0'
-  prtcorrect: '<span style="font-size: 1.5em; color:green;"><i class="fa fa-check"></i></span> Correct answer, well done.'
+  prtcorrect: '[[commonstring key="symbolicprtcorrectfeedback"/]] [[commonstring key="defaultprtcorrectfeedback"/]]'
   prtcorrectformat: html
-  prtpartiallycorrect: '<span style="font-size: 1.5em; color:orange;"><i class="fa fa-adjust"></i></span> Your answer is partially correct.'
+  prtpartiallycorrect: '[[commonstring key="symbolicprtpartiallycorrectfeedback"/]] [[commonstring key="defaultprtpartiallycorrectfeedback"/]]'
   prtpartiallycorrectformat: html
-  prtincorrect: '<span style="font-size: 1.5em; color:red;"><i class="fa fa-times"></i></span> Incorrect answer.'
+  prtincorrect: '[[commonstring key="symbolicprtincorrectfeedback"/]] [[commonstring key="defaultprtincorrectfeedback"/]]'
   prtincorrectformat: html
   decimals: .
   scientificnotation: '*10'

--- a/tests/yaml_converter_test.php
+++ b/tests/yaml_converter_test.php
@@ -75,12 +75,12 @@ final class yaml_converter_test extends \advanced_testcase {
         );
         $this->assertEquals('html', (string) $xml->question->prtcorrect['format']);
         $this->assertEquals(
-            '<span style="font-size: 1.5em; color:orange;"><i class="fa fa-adjust"></i></span> Your answer is partially correct.',
+            '[[commonstring key="symbolicprtpartiallycorrectfeedback"/]] [[commonstring key="defaultprtpartiallycorrectfeedback"/]]',
             (string) $xml->question->prtpartiallycorrect->text
         );
         $this->assertEquals('html', (string) $xml->question->prtpartiallycorrect['format']);
         $this->assertEquals(
-            '<span style="font-size: 1.5em; color:red;"><i class="fa fa-times"></i></span> Incorrect answer.',
+            '[[commonstring key="symbolicprtincorrectfeedback"/]] [[commonstring key="defaultprtincorrectfeedback"/]]',
             (string) $xml->question->prtincorrect->text
         );
         $this->assertEquals('html', (string) $xml->question->prtincorrect['format']);
@@ -233,12 +233,12 @@ final class yaml_converter_test extends \advanced_testcase {
         );
         $this->assertEquals('html', (string) $xml->question->prtcorrect['format']);
         $this->assertEquals(
-            '<span style="font-size: 1.5em; color:orange;"><i class="fa fa-adjust"></i></span> Your answer is partially correct.',
+            '[[commonstring key="symbolicprtpartiallycorrectfeedback"/]] [[commonstring key="defaultprtpartiallycorrectfeedback"/]]',
             (string) $xml->question->prtpartiallycorrect->text
         );
         $this->assertEquals('html', (string) $xml->question->prtpartiallycorrect['format']);
         $this->assertEquals(
-            '<span style="font-size: 1.5em; color:red;"><i class="fa fa-times"></i></span> Incorrect answer.',
+            '[[commonstring key="symbolicprtincorrectfeedback"/]] [[commonstring key="defaultprtincorrectfeedback"/]]',
             (string) $xml->question->prtincorrect->text
         );
         $this->assertEquals('html', (string) $xml->question->prtincorrect['format']);
@@ -371,17 +371,17 @@ final class yaml_converter_test extends \advanced_testcase {
         );
         $this->assertEquals('html', $question->generalfeedback['format']);
         $this->assertEquals(
-            '<span style="font-size: 1.5em; color:green;"><i class="fa fa-check"></i></span> Correct answer, well done.',
+            '[[commonstring key="symbolicprtcorrectfeedback"/]] [[commonstring key="defaultprtcorrectfeedback"/]]',
             $question->prtcorrect->text
         );
         $this->assertEquals('html', $question->prtpartiallycorrect['format']);
         $this->assertEquals(
-            '<span style="font-size: 1.5em; color:orange;"><i class="fa fa-adjust"></i></span> Your answer is partially correct.',
+            '[[commonstring key="symbolicprtpartiallycorrectfeedback"/]] [[commonstring key="defaultprtpartiallycorrectfeedback"/]]',
             $question->prtpartiallycorrect->text
         );
         $this->assertEquals('html', $question->prtincorrect['format']);
         $this->assertEquals(
-            '<span style="font-size: 1.5em; color:red;"><i class="fa fa-times"></i></span> Incorrect answer.',
+            '[[commonstring key="symbolicprtincorrectfeedback"/]] [[commonstring key="defaultprtincorrectfeedback"/]]',
             $question->prtincorrect->text
         );
         $this->assertEquals('html', $question->prtcorrect['format']);
@@ -487,17 +487,17 @@ final class yaml_converter_test extends \advanced_testcase {
         );
         $this->assertEquals('html', $question->generalfeedback['format']);
         $this->assertEquals(
-            '<span style="font-size: 1.5em; color:green;"><i class="fa fa-check"></i></span> Correct answer, well done.',
+            '[[commonstring key="symbolicprtcorrectfeedback"/]] [[commonstring key="defaultprtcorrectfeedback"/]]',
             $question->prtcorrect->text
         );
         $this->assertEquals('html', $question->prtpartiallycorrect['format']);
         $this->assertEquals(
-            '<span style="font-size: 1.5em; color:orange;"><i class="fa fa-adjust"></i></span> Your answer is partially correct.',
+            '[[commonstring key="symbolicprtpartiallycorrectfeedback"/]] [[commonstring key="defaultprtpartiallycorrectfeedback"/]]',
             $question->prtpartiallycorrect->text
         );
         $this->assertEquals('html', $question->prtincorrect['format']);
         $this->assertEquals(
-            '<span style="font-size: 1.5em; color:red;"><i class="fa fa-times"></i></span> Incorrect answer.',
+            '[[commonstring key="symbolicprtincorrectfeedback"/]] [[commonstring key="defaultprtincorrectfeedback"/]]',
             $question->prtincorrect->text
         );
         $this->assertEquals('html', $question->prtcorrect['format']);


### PR DESCRIPTION
Update default feedback options to match STACK issue #1684, https://github.com/maths/moodle-qtype_stack/issues/1684